### PR TITLE
Update ember to 1.10-beta.3

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,9 +1,9 @@
 {
   "name": "diesel",
   "dependencies": {
-    "handlebars": "~1.3.0",
+    "handlebars": "2.0.0",
     "jquery": "^1.11.1",
-    "ember": "1.8.1",
+    "ember": "1.10.0-beta.3",
     "ember-data": "1.0.0-beta.12",
     "ember-resolver": "~0.1.11",
     "loader.js": "stefanpenner/loader.js#1.0.1",
@@ -20,9 +20,5 @@
     "pretender": "0.3.1",
     "JavaScript-MD5": "~1.1.0",
     "bootstrap-sass": "twbs/bootstrap-sass#3.3.1"
-  },
-  "resolutions": {
-    "ember-data": "1.0.0-beta.11",
-    "ember": "1.8.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,12 +19,12 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.0.0",
-    "broccoli-ember-hbs-template-compiler": "^1.6.1",
     "broccoli-sass": "^0.3.3",
     "ember-cli": "0.1.5",
     "ember-cli-content-security-policy": "0.3.0",
     "ember-cli-font-awesome": "0.0.4",
     "ember-cli-gravatar": "^1.2.1",
+    "ember-cli-htmlbars": "^0.6.0",
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.3.0",
     "ember-cli-pretender": "^0.3.1",


### PR DESCRIPTION
More info about 1.10 is here: http://emberjs.com/blog/2014/12/08/ember-1-9-0-released.html

Recommended to do the following after merging:

  * rm -rf tmp/ bower_components/
  * npm install
  * bower install