### PR TITLE
Add support for email verification

### DIFF
--- a/app/adapters/verification.js
+++ b/app/adapters/verification.js
@@ -1,0 +1,3 @@
+import AuthAdapter from './auth';
+
+export default AuthAdapter.extend();

--- a/app/app.js
+++ b/app/app.js
@@ -2,13 +2,21 @@ import Ember from 'ember';
 import Resolver from 'ember/resolver';
 import loadInitializers from 'ember/load-initializers';
 import config from './config/environment';
+import { getUrlParameter } from './utils/url-parameters';
+import { replaceLocation } from './utils/location';
 
 Ember.MODEL_FACTORY_INJECTIONS = true;
 
 var App = Ember.Application.extend({
   modulePrefix: config.modulePrefix,
   podModulePrefix: config.podModulePrefix,
-  Resolver: Resolver
+  Resolver: Resolver,
+  ready: function(){
+    var verificationCode = getUrlParameter(window.location, 'verification_code');
+    if (verificationCode) {
+      replaceLocation('/verify/'+verificationCode);
+    }
+  }
 });
 
 loadInitializers(App, config.modulePrefix);

--- a/app/error/controller.js
+++ b/app/error/controller.js
@@ -1,0 +1,15 @@
+import Ember from "ember";
+
+export default Ember.Controller.extend({
+
+  title: function(){
+    return this.get('model.status') || this.get('model.name');
+  }.property('model.status', 'model.name'),
+
+  subTitle: Ember.computed.alias('model.statusText'),
+
+  message: function(){
+    return this.get('model.responseJSON.message')+'.' || 'Our JavaScript raised an exception.';
+  }.property('model.responseJSON.message')
+
+});

--- a/app/error/route.js
+++ b/app/error/route.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+});

--- a/app/error/template.hbs
+++ b/app/error/template.hbs
@@ -1,0 +1,107 @@
+<style type="text/css">
+  .wf-loading .blog-title, .wf-loading .post-title {
+      /* Prevents FOUT while fonts are loading */
+      visibility: hidden;
+    }
+</style>
+<style>
+  body {
+    background-color: white;
+    color: black;
+    text-align: center;
+    font-family: "proxima-nova", "open-sans", sans-serif;
+  }
+
+  div.error-logo {
+    height: 250px;
+    width: 250px;
+    margin: 0 auto 0 auto;
+    background-image: url('/error-logo.png');
+  }
+
+  div.dialog {
+    width: 500px;
+    margin: 75px auto 0 auto;
+    padding: 7px 4em 0 4em;
+  }
+
+  h1 {
+    color: #006699;
+    line-height: 1em;
+  }
+
+  body > p {
+    width: 500px;
+    margin: 0 auto 1em;
+    padding: 1em 0;
+    background-color: #003366;
+    border: 1px solid #CCC;
+    border-right-color: #999;
+    border-bottom-color: #999;
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+    border-top-color: #DADADA;
+    color: #666;
+    box-shadow:0 3px 8px rgba(50, 50, 50, 0.17);
+  }
+
+  h1.error-code {
+    font-size: 100px;
+    color: #003366;
+    margin: 0 auto;
+  }
+
+  ul {
+    list-style-type: none;
+    display: inline-block;
+    padding-left: 0px;
+  }
+
+  ul > li {
+    display: inline;
+    padding-left: 10px;
+    padding-right: 10px;
+  }
+
+  a {
+    color: #006699;
+  }
+  a:link {
+    text-decoration: none;
+  }
+  a:visited {
+    text-decoration: none;
+  }
+  a:hover {
+    text-decoration: underline;
+  }
+  a:active {
+    text-decoration: none;
+  }
+
+  .circle-icon {
+    display: block;
+    margin: 0 auto;
+    height: 40px;
+    width: 40px;
+    background-image: url('/tiny-greyscale-logo.png');
+  }
+
+  .circle-icon:hover {
+    background-image: url('/tiny-color-logo.png');
+  }
+
+</style>
+
+<div class="dialog">
+  <div class="error-logo"></div>
+  <h1 class="error-code">{{title}}</h1>
+  <h1>{{subTitle}}</h1>
+  <p>{{message}} Maybe the URL you visited is no longer valid?</p>
+</div>
+<ul>
+  <li><a href="http://status.aptible.com">Aptible Status</a></li>
+  <li><a href="https://twitter.com/aptiblestatus">@aptiblestatus</a></li>
+  <li><a href="http://support.aptible.com">Contact Support</a></li>
+</ul>
+<a class="circle-icon" href="https://www.aptible.com"></a>

--- a/app/models/verification.js
+++ b/app/models/verification.js
@@ -1,0 +1,6 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  verificationCode: DS.attr('string'),
+  type: DS.attr('string')
+});

--- a/app/router.js
+++ b/app/router.js
@@ -1,33 +1,57 @@
-import Ember from 'ember';
-import config from './config/environment';
+import Ember from "ember";
+import config from "./config/environment";
 
 var Router = Ember.Router.extend({
   location: config.locationType
 });
 
 Router.map(function() {
-  this.route('apps', {}, function(){
-    // show an individual app
-    this.route('show', {path: '/:app_id'}, function(){
-      this.route('operations');
+  this.route("apps", {}, function() {
+    this.route("show", {
+      path: "/:app_id"
+    }, function() {
+      this.route("operations");
     });
   });
-  this.route('service', {path: 'services/:service_id'}, function(){
-    this.route('new-vhost', {path: 'vhosts/new'});
-  });
-  this.route('databases', {}, function(){
-    this.route('show', {path: '/:database_id'}, function(){
-      this.route('operations');
+
+  this.route("service", {
+    path: "services/:service_id"
+  }, function() {
+    this.route("new-vhost", {
+      path: "vhosts/new"
     });
   });
-  this.route('login');
-  this.route('logout');
-  this.route('stack', {path: 'stacks/:stack_id'}, function(){
-    this.route('new-database', {path: 'databases/new'});
-    this.route('new-app', {path: 'apps/new'});
-    this.route('settings');
+
+  this.route("databases", {}, function() {
+    this.route("show", {
+      path: "/:database_id"
+    }, function() {
+      this.route("operations");
+    });
   });
-  this.route('signup');
+
+  this.route("login");
+  this.route("logout");
+
+  this.route("stack", {
+    path: "stacks/:stack_id"
+  }, function() {
+    this.route("new-database", {
+      path: "databases/new"
+    });
+
+    this.route("new-app", {
+      path: "apps/new"
+    });
+
+    this.route("settings");
+  });
+
+  this.route("signup");
+
+  this.route("verify", {
+    path: "verify/:verification_code"
+  });
 });
 
 export default Router;

--- a/app/utils/url-parameters.js
+++ b/app/utils/url-parameters.js
@@ -1,0 +1,20 @@
+export function getUrlParameters(loc) {
+  var a = loc.search.substr(1).split('&');
+  var b = {};
+  if (a.length > 0) {
+    for (var i = 0; i < a.length; ++i) {
+      var p=a[i].split('=', 2);
+      if (p.length === 1) {
+        b[p[0]] = "";
+      } else {
+        b[p[0]] = decodeURIComponent(p[1].replace(/\+/g, " "));
+      }
+    }
+  }
+  return b;
+}
+
+export function getUrlParameter(loc, name) {
+  var params = getUrlParameters(loc);
+  return params ? params[name] : undefined;
+}

--- a/app/verify/route.js
+++ b/app/verify/route.js
@@ -1,0 +1,27 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+
+  beforeModel: function(){
+    var route = this;
+    if (!this.session.get('isAuthenticated')) {
+      return this.session.fetch('aptible').catch(function(){
+        route.transitionTo('login');
+      });
+    }
+  },
+
+  model: function(params){
+    var options = {
+      verificationCode: params.verification_code,
+      type: 'email'
+    };
+    var verification = this.store.createRecord('verification', options);
+    return verification.save();
+  },
+
+  afterModel: function() {
+    this.replaceWith('index');
+  }
+
+});

--- a/tests/acceptance/verification-test.js
+++ b/tests/acceptance/verification-test.js
@@ -1,0 +1,56 @@
+import Ember from 'ember';
+import startApp from '../helpers/start-app';
+import { stubRequest, jsonMimeType } from '../helpers/fake-server';
+
+var App;
+
+module('Acceptance: Verification', {
+  setup: function() {
+    App = startApp();
+  },
+  teardown: function() {
+    Ember.run(App, 'destroy');
+  }
+});
+
+test('visiting /verify/some-code requires auth', function() {
+  visit('/verify/some-code');
+  andThen(function(){
+    equal(currentPath(), 'login');
+  });
+});
+
+test('visiting /verify/some-code creates verification', function() {
+  stubStacks(); // For loading index
+
+  var verificationCode = 'some-code';
+
+  stubRequest('post', '/verifications', function(request){
+    var params = JSON.parse(request.requestBody);
+    equal(params.verification_code, verificationCode, 'correct code is passed');
+    return this.success({
+      id: 'this-id',
+      verification_code: verificationCode
+    });
+  });
+
+  signInAndVisit('/verify/'+verificationCode);
+  andThen(function(){
+    equal(currentPath(), 'apps.index');
+  });
+});
+
+test('failed verificaton directs to error page', function() {
+  var verificationCode = 'some-code';
+
+  stubRequest('post', '/verifications', function(request){
+    var params = JSON.parse(request.requestBody);
+    equal(params.verification_code, verificationCode, 'correct code is passed');
+    return [401, jsonMimeType, {}];
+  });
+
+  signInAndVisit('/verify/'+verificationCode);
+  andThen(function(){
+    equal(currentPath(), 'error');
+  });
+});

--- a/tests/helpers/fake-server.js
+++ b/tests/helpers/fake-server.js
@@ -12,7 +12,7 @@ function raiseOnUnhandledRequest(verb, path, request){
   throw "FakeServer received unhandled request for :" + verb + " " + path;
 }
 
-var jsonMimeType = {"Content-Type": "application/json"};
+export var jsonMimeType = {"Content-Type": "application/json"};
 
 function errorRequest(status, errors){
   // if called without `status`

--- a/tests/unit/utils/url-parameters-test.js
+++ b/tests/unit/utils/url-parameters-test.js
@@ -1,0 +1,28 @@
+import {
+  test
+} from 'ember-qunit';
+
+import { getUrlParameter, getUrlParameters } from '../../../utils/url-parameters';
+
+module('Unit: getUrlParameter');
+
+test('reads a parameter from a location object', function(){
+  var location = { search: '?foo=bar' };
+  var result = getUrlParameter(location, 'foo');
+  equal(result, 'bar', 'foo param is read');
+});
+
+test('reads no parameter from a location object without any', function(){
+  var location = { search: '' };
+  var result = getUrlParameter(location, 'foo');
+  equal(result, undefined, 'foo param is not present');
+});
+
+module('Unit: getUrlParameters');
+
+test('reads paramters', function(){
+  var location = { search: '?foo=bar&meep=with%20space' };
+  var result = getUrlParameters(location);
+  equal(result.foo, 'bar', 'foo param is present');
+  equal(result.meep, 'with space', 'meep param is present and decoded');
+});

--- a/tests/unit/verify/route-test.js
+++ b/tests/unit/verify/route-test.js
@@ -1,0 +1,14 @@
+import {
+  moduleFor,
+  test
+} from 'ember-qunit';
+
+moduleFor('route:verify', 'VerifyRoute', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+test('it exists', function() {
+  var route = this.subject();
+  ok(route);
+});


### PR DESCRIPTION
@bantic for you to review/merge. /cc @fancyremarker we worked on this yesterday.

Adds support to diesel for email verification. This is still a stand-alone feature, and not part of the wizard flow.

Also adds a top level error page, required to show a default message for invalid tokens.