### PR TITLE
Add organization to account creation flow

### DIFF
--- a/app/adapters/organization.js
+++ b/app/adapters/organization.js
@@ -1,0 +1,3 @@
+import AuthAdapter from './auth';
+
+export default AuthAdapter.extend();

--- a/app/models/organization.js
+++ b/app/models/organization.js
@@ -1,0 +1,12 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  name: DS.attr('string'),
+  primaryPhone: DS.attr('string'),
+  emergencyPhone: DS.attr('string'),
+  city: DS.attr('string'),
+  state: DS.attr('string'),
+  zip: DS.attr('string'),
+  address: DS.attr('string'),
+  plan: DS.attr('string')
+});

--- a/app/signup/controller.js
+++ b/app/signup/controller.js
@@ -1,0 +1,33 @@
+import Ember from "ember";
+import EmberValidations from "ember-validations";
+
+export default Ember.Controller.extend(EmberValidations.Mixin, {
+  hasSubmitted: false,
+
+  validations: {
+    'organization.name': {
+      presence: true,
+      length: { minimum: 5 }
+    }
+  },
+
+  actions: {
+
+    signup: function(){
+      var hasSubmitted = this.get('hasSubmitted');
+      if (!hasSubmitted) {
+        this.set('hasSubmitted', true);
+      }
+      var controller = this;
+      this.validate().then(function(){
+        var user = controller.get('model');
+        var organization = controller.get('organization');
+        controller.get('target').send('signup', user, organization);
+      }).catch(function(){
+        // Silence the validation exception
+      });
+    }
+
+  }
+
+});

--- a/app/signup/route.js
+++ b/app/signup/route.js
@@ -11,14 +11,16 @@ export default Ember.Route.extend({
     }
   },
 
-  model: function() {
-    return this.store.createRecord('user');
+  setupController: function(controller){
+    var user = this.store.createRecord('user');
+    var organization = this.store.createRecord('organization');
+    controller.set('model', user);
+    controller.set('organization', organization);
   },
 
   actions: {
 
-    signup: function(){
-      var user = this.currentModel;
+    signup: function(user, organization){
       var session = this.session;
       var email = user.get('email');
       var password = user.get('password');
@@ -26,6 +28,8 @@ export default Ember.Route.extend({
         var credentials = buildCredentials(email, password);
         // TODO: This option causes a user request to fetch data already present in the identity map
         return session.open('aptible', credentials);
+      }).then(function(){
+        return organization.save();
       }).then(function(){
         replaceLocation([config.legacyDashboardHost, 'organizations/new'].join('/'));
       }, function(){});

--- a/app/signup/template.hbs
+++ b/app/signup/template.hbs
@@ -29,12 +29,31 @@
 </div>
 <div class="input-group">
   <span class="input-group-addon">
-    <i class="fa fa-envelope"></i>
+    <i class="fa fa-user"></i>
   </span>
   {{input type="text"
       value=model.name
       class="form-control"
       placeholder="Full Name"}}
+</div>
+{{#if hasSubmitted}}
+  {{#if errors.organization.name}}
+    <div class="alert alert-warning fade in">
+      {{#each message in errors.organization.name}}
+        <p>Organization name {{message}}</p>
+      {{/each}}
+    </div>
+  {{/if}}
+{{/if}}
+<div class="input-group">
+  <span class="input-group-addon">
+    <i class="fa fa-users"></i>
+  </span>
+  {{input type="text"
+      name="organization"
+      value=organization.name
+      class="form-control"
+      placeholder="Organization"}}
 </div>
 <div class="input-group">
   <span class="input-group-addon">

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "ember-data": "1.0.0-beta.12",
     "ember-data-hal-9000": "git://github.com/201-created/ember-data-hal-9000#8ed5d82a6483ac5f3f6a3af100160435123578cb",
     "ember-export-application-global": "^1.0.0",
+    "ember-validations": "^2.0.0-alpha.1",
     "express": "^4.8.5",
     "glob": "^4.0.5",
     "torii": "^0.2.2"

--- a/tests/acceptance/authentication-test.js
+++ b/tests/acceptance/authentication-test.js
@@ -169,8 +169,12 @@ test('Creating an account directs to login', function() {
   var email = 'good@email.com';
   var password = 'correct';
   var userUrl = '/users/my-user';
+  var organization = 'Great Co.';
 
-  stubRequest('post', '/users', function(){
+  stubRequest('post', '/users', function(request){
+    var params = JSON.parse(request.requestBody);
+    equal(params.email, email, 'correct email is passed');
+    equal(params.password, password, 'correct password is passed');
     return this.success({
       id: 'my-user',
       email: email
@@ -188,12 +192,37 @@ test('Creating an account directs to login', function() {
       email: email
     });
   });
+  stubRequest('post', '/organizations', function(request){
+    var params = JSON.parse(request.requestBody);
+    equal(params.name, organization, 'correct organization is passed');
+    return this.success({
+      id: 'my-organization',
+      name: organization
+    });
+  });
 
   visit('/signup');
   fillIn('input[type=email]', email);
   fillIn('input[type=password]', password);
+  fillIn('input[name=organization]', organization);
   click('button:contains(Create Account)');
   andThen(function(){
     locationUpdatedTo('http://legacy-dashboard-host.com/organizations/new');
+  });
+});
+
+test('Creating an account waits on a valid organization name', function() {
+  var email = 'good@email.com';
+  var password = 'correct';
+  var userUrl = '/users/my-user';
+  var organization = 'bad';
+
+  visit('/signup');
+  fillIn('input[type=email]', email);
+  fillIn('input[type=password]', password);
+  fillIn('input[name=organization]', organization);
+  click('button:contains(Create Account)');
+  andThen(function(){
+    equal(currentPath(), 'signup', 'path does not change');
   });
 });

--- a/tests/unit/models/organization-test.js
+++ b/tests/unit/models/organization-test.js
@@ -1,0 +1,15 @@
+import {
+  moduleForModel,
+  test
+} from 'ember-qunit';
+
+moduleForModel('organization', 'Organization', {
+  // Specify the other units that are required for this test.
+  needs: []
+});
+
+test('it exists', function() {
+  var model = this.subject();
+  // var store = this.store();
+  ok(!!model);
+});


### PR DESCRIPTION
Moves us toward https://github.com/aptible/diesel.aptible.com/issues/30#issuecomment-69032950

The organization name can now be specified when creating an account. This will let us bypass the organization creation screen for most users. There is a client-side validation that ensures the user cannot forget to specify an organization name. In a later PR we should expand that to check and see if an organization with that names exists.