### PR TITLE
Wwwizard

### DIFF
--- a/app/adapters/subscription.js
+++ b/app/adapters/subscription.js
@@ -1,0 +1,8 @@
+import AuthAdapter from './auth';
+import buildURLWithPrefixMap from '../utils/build-url-with-prefix-map';
+
+export default AuthAdapter.extend({
+  buildURL: buildURLWithPrefixMap({
+    'organizations': 'organization.id'
+  })
+});

--- a/app/models/subscription.js
+++ b/app/models/subscription.js
@@ -1,0 +1,7 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  stripeToken: DS.attr('string'),
+  plan: DS.attr('string'),
+  organization: DS.belongsTo('organization', {async: true})
+});

--- a/app/router.js
+++ b/app/router.js
@@ -55,6 +55,7 @@ Router.map(function() {
 
   this.route("welcome", function() {
     this.route("first-app");
+    this.route("payment-info");
   });
 });
 

--- a/app/utils/stripe.js
+++ b/app/utils/stripe.js
@@ -1,0 +1,39 @@
+/* globals Stripe */
+
+import jQuery from 'jquery';
+import Ember from 'ember';
+import config from '../config/environment';
+
+var loadPromise;
+
+function load(){
+  if(!loadPromise) {
+    if (window.Stripe) {
+      loadPromise = Ember.RSVP.resolve();
+    } else {
+      loadPromise = new Ember.RSVP.Promise(function(resolve, reject) {
+        jQuery.getScript('https://js.stripe.com/v2/').then(Ember.run.bind(null, resolve), Ember.run.bind(null, reject));
+      }).then(function() {
+        Stripe.setPublishableKey(config.stripePublishableKey);
+      });
+    }
+  }
+
+  return loadPromise;
+}
+
+function createStripeToken(options) {
+  return load().then(function() {
+    return new Ember.RSVP.Promise(function(resolve, reject) {
+      Stripe.card.createToken(options, function(status, result) {
+        if(result.error) {
+          Ember.run(null, reject, result.error);
+        } else {
+          Ember.run(null, resolve, result);
+        }
+      });
+    });
+  });
+}
+
+export { createStripeToken };

--- a/app/welcome/first-app/route.js
+++ b/app/welcome/first-app/route.js
@@ -1,6 +1,5 @@
 import Ember from 'ember';
 import { read, write } from '../../utils/storage';
-import { replaceLocation } from "../../utils/location";
 import config from "../../config/environment";
 
 export var firstAppKey = '_aptible_firstAppData';
@@ -8,7 +7,6 @@ export var firstAppKey = '_aptible_firstAppData';
 var subscriptionUrl = [config.legacyDashboardHost, 'subscriptions/new'].join('/');
 
 export default Ember.Route.extend({
-
   model: function(){
     var firstApp = read(firstAppKey);
 
@@ -33,7 +31,7 @@ export default Ember.Route.extend({
 
     create: function(model){
       write(firstAppKey, model);
-      replaceLocation( subscriptionUrl );
+      this.transitionTo('welcome.payment-info');
     },
 
     selectDbType: function(dbType){

--- a/app/welcome/first-app/template.hbs
+++ b/app/welcome/first-app/template.hbs
@@ -5,7 +5,7 @@
 </h3>
 <div class="sub-heading">
   Or, if you aren't ready for this,
-  <a {{bind-attr href=subscriptionUrl}}>skip ahead</a>.
+  {{link-to "skip ahead" "welcome.payment-info"}}.
 </div>
 
 <div class="panel panel-default focus-panel">

--- a/app/welcome/payment-info/route.js
+++ b/app/welcome/payment-info/route.js
@@ -1,0 +1,45 @@
+import Ember from 'ember';
+import { createStripeToken } from '../../utils/stripe';
+
+export default Ember.Route.extend({
+  model: function() {
+    return {};
+  },
+
+  actions: {
+    create: function(model) {
+      var route = this;
+      var store = this.store;
+      var controller = this.controllerFor('welcome/payment-info');
+
+      var options = {
+        name: model.name,
+        number: model.number,
+        exp_month: model.expMonth,
+        exp_year: model.expYear,
+        cvc: model.cvc,
+        address_zip: model.zip
+      };
+
+      Ember.RSVP.hash({
+        stripeResponse: createStripeToken(options),
+        // TODO: the organization should probabaly be loaded
+        // when the route is entered and the name displayed when
+        // entering payment information
+        organizations: store.find('organization')
+      }).then(function(result) {
+        var subscription = store.createRecord('subscription', {
+          plan: 'development',
+          stripeToken: result.stripeResponse.id,
+          organization: result.organizations.objectAt(0)
+        });
+        return subscription.save();
+      }).then(function(){
+        // TODO: Change to verification page when ready
+        route.transitionTo('apps.index');
+      }, function(error) {
+        controller.set('error', error);
+      });
+    }
+  }
+});

--- a/app/welcome/payment-info/template.hbs
+++ b/app/welcome/payment-info/template.hbs
@@ -1,0 +1,61 @@
+
+{{outlet}}
+<div class="container">
+  <div class="row">
+    <div class="col-xs-6 col-xs-offset-3">
+      <h3 class="heading">Payment Information</h3>
+
+      <div class="panel panel-default focus-panel">
+        <div class="panel-body">
+          <form role="form">
+
+            {{#if error}}
+              <div class="alert alert-warning fade in">
+                <p>{{error.message}}</p>
+              </div>
+            {{/if}}
+
+            <div class="form-group">
+              <label>Plan</label>
+              {{input class="form-control" value=model.plan name="plan"}}
+            </div>
+
+            <div class="form-group">
+              <label>Name</label>
+              {{input class="form-control" value=model.name name="name"}}
+            </div>
+
+            <div class="form-group">
+              <label>Card Number</label>
+              {{input class="form-control" value=model.number name="number"}}
+            </div>
+
+            <div class="form-group">
+              <label>Expiration Month</label>
+              {{input class="form-control" value=model.expMonth name="exp-month" maxlength="2"}}
+            </div>
+
+            <div class="form-group">
+              <label>Expiration Year</label>
+              {{input class="form-control" value=model.expYear name="exp-year" maxlength="4"}}
+            </div>
+
+            <div class="form-group">
+              <label>CVC</label>
+              {{input class="form-control" value=model.cvc name="cvc"}}
+            </div>
+
+            <div class="form-group">
+              <label>Zip</label>
+              {{input class="form-control" value=model.zip name="zip"}}
+            </div>
+
+            <div class="form-group">
+              <button class="btn btn-primary" {{action 'create' model}}>Save</button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/welcome/route.js
+++ b/app/welcome/route.js
@@ -1,0 +1,9 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  beforeModel: function() {
+    if(!this.session.get('isAuthenticated')) {
+      this.replaceWith('login');
+    }
+  }
+});

--- a/config/environment.js
+++ b/config/environment.js
@@ -12,7 +12,7 @@ module.exports = function(environment) {
     legacyDashboardHost: "http://localhost:3000",
 
     authTokenKey: '_aptible_authToken',
-
+    stripePublishableKey: 'pk_test_eiw5HXHTAgTwyNnV9I5ruCrA',
     replaceLocation: true,
 
     EmberENV: {
@@ -34,7 +34,8 @@ module.exports = function(environment) {
     contentSecurityPolicy: {
       'connect-src': "'self' http://localhost:4000 http://localhost:4001 ws://localhost:35729 ws://0.0.0.0:35729",
       'style-src': "'self' 'unsafe-inline'",
-      'img-src': "'self' http://www.gravatar.com https://secure.gravatar.com"
+      'img-src': "'self' http://www.gravatar.com https://secure.gravatar.com",
+      'script-src': "'self' https://js.stripe.com https://api.stripe.com"
     }
 
   };

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -52,7 +52,9 @@
     "stubStack",
     "stubStacks",
     "locationUpdatedTo",
-    "expectRequiresAuthentication"
+    "expectRequiresAuthentication",
+    "stubOrganizations",
+    "locationUpdatedTo"
   ],
   "node": false,
   "browser": false,

--- a/tests/acceptance/welcome/first-app-test.js
+++ b/tests/acceptance/welcome/first-app-test.js
@@ -17,6 +17,14 @@ module('Acceptance: WelcomeFirstApp', {
   }
 });
 
+test('visiting /welcome/first-app when not logged in', function() {
+  visit('/welcome/first-app');
+
+  andThen(function() {
+    equal(currentPath(), 'login');
+  });
+});
+
 test('submitting a first app directs to subscriptions', function() {
   var appHandle = 'my-app';
 
@@ -27,6 +35,6 @@ test('submitting a first app directs to subscriptions', function() {
   andThen(function() {
     var stored = read(firstAppKey);
     equal(stored.appHandle, appHandle, 'app handle is saved in localStorage');
-    locationUpdatedTo('http://legacy-dashboard-host.com/subscriptions/new');
+    equal(currentPath(), 'welcome.payment-info', 'redirected to payment info');
   });
 });

--- a/tests/acceptance/welcome/payment-info-test.js
+++ b/tests/acceptance/welcome/payment-info-test.js
@@ -1,0 +1,87 @@
+import Ember from 'ember';
+import startApp from '../../helpers/start-app';
+import { mockStripe } from '../../helpers/mock-stripe';
+import { stubRequest } from "../../helpers/fake-server";
+
+var application;
+var oldCreateToken;
+
+module('Acceptance: WelcomePaymentInfo', {
+  setup: function() {
+    application = startApp();
+    oldCreateToken = mockStripe.card.createToken;
+  },
+  teardown: function() {
+    Ember.run(application, 'destroy');
+    mockStripe.card.createToken = oldCreateToken;
+  }
+});
+
+test('visiting /welcome/payment-info when not logged in', function() {
+  expectRequiresAuthentication('/welcome/payment-info');
+});
+
+test('submitting empty payment info raises an error', function() {
+  mockStripe.card.createToken = function(options, fn) {
+    setTimeout(function(){
+      fn(422, { error: { message: 'Failure' } });
+    }, 2);
+  };
+
+  stubOrganizations();
+
+  signInAndVisit('/welcome/payment-info');
+  click('button:contains(Save)');
+
+  andThen(function() {
+    equal(currentPath(), 'welcome.payment-info');
+    var error = find('p:contains(Failure)');
+    ok(error.length, 'errors are on the page');
+  });
+});
+
+test('submitting valid payment info should be successful', function() {
+  expect(8);
+  // This is to load apps.index
+  stubStacks();
+  var name = 'Bob Boberson';
+  var cardNumber = '4242424242424242';
+  var cvc = '123';
+  var expMonth = '03';
+  var expYear = '2019';
+  var addressZip = '11111';
+  var stripeToken = 'some-token';
+
+  stubRequest('post', '/organizations/1/subscriptions', function(request){
+    var params = JSON.parse(request.requestBody);
+    equal(params.stripe_token, stripeToken, 'stripe token is correct');
+    return this.success();
+  });
+
+  stubOrganizations();
+
+  mockStripe.card.createToken = function(options, fn) {
+    equal(options.name, name, 'name is correct');
+    equal(options.number, cardNumber, 'card number is correct');
+    equal(options.cvc, cvc, 'cvc is correct');
+    equal(options.exp_month, expMonth, 'exp month is correct');
+    equal(options.exp_year, expYear, 'exp year is correct');
+    equal(options.address_zip, addressZip, 'zip is correct');
+    setTimeout(function(){
+      fn(200, { id: stripeToken });
+    }, 2);
+  };
+
+  signInAndVisit('/welcome/payment-info');
+  fillIn('[name=name]', name);
+  fillIn('[name=number]', cardNumber);
+  fillIn('[name=cvc]', cvc);
+  fillIn('[name=exp-month]', expMonth);
+  fillIn('[name=exp-year]', expYear);
+  fillIn('[name=zip]', addressZip);
+  click('button:contains(Save)');
+
+  andThen(function() {
+    equal(currentPath(), 'apps.index');
+  });
+});

--- a/tests/helpers/aptible-helpers.js
+++ b/tests/helpers/aptible-helpers.js
@@ -154,3 +154,20 @@ Ember.Test.registerHelper('expectStackHeader', function(app, stackHandle){
   var handle = find('header .account-handle:contains(' + stackHandle + ')');
   ok(handle.length, 'expected stack header with handle: ' + stackHandle);
 });
+
+Ember.Test.registerHelper('stubOrganizations', function(app){
+  stubRequest('get', '/organizations', function(request){
+    return this.success({
+      _links: {},
+      _embedded: {
+        organizations: [{
+          _links: {
+          },
+          id: 1,
+          name: 'Sprocket Co',
+          type: 'organization'
+        }]
+      }
+    });
+  });
+});

--- a/tests/helpers/mock-stripe.js
+++ b/tests/helpers/mock-stripe.js
@@ -1,0 +1,20 @@
+var oldStripe;
+
+export var mockStripe = {
+  card: {
+    createToken: function(options, fn) {
+      setTimeout(function(){
+        fn(404, {});
+      }, 2);
+    }
+  }
+};
+
+export function stubStripe(){
+  oldStripe = window.Stripe;
+  window.Stripe = mockStripe;
+}
+
+export function teardownStripe(){
+  window.Stripe = oldStripe;
+}

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -5,6 +5,7 @@ import {
 import config from "../config/environment";
 import { locationHistory } from '../utils/location';
 import FakeServer from "./helpers/fake-server";
+import { stubStripe, teardownStripe } from "./helpers/mock-stripe";
 
 setResolver(resolver);
 
@@ -21,8 +22,10 @@ QUnit.testStart(function(){
 
 QUnit.testStart(function(){
   FakeServer.start();
+  stubStripe();
 });
 
 QUnit.testDone(function(){
+  teardownStripe();
   FakeServer.stop();
 });

--- a/tests/unit/models/subscription-test.js
+++ b/tests/unit/models/subscription-test.js
@@ -1,0 +1,43 @@
+import {
+  moduleForModel,
+  test
+} from 'ember-qunit';
+import Ember from "ember";
+import { stubRequest } from '../../helpers/fake-server';
+
+moduleForModel('subscription', 'Subscription', {
+  needs: ['model:organization', 'adapter:subscription', 'serializer:application']
+});
+
+test('data is posted upon save', function() {
+  expect(4);
+  var stripeToken = 'some-token';
+  var plan = 'development';
+  var organizationId = 'org-1';
+
+  stubRequest('post', '/organizations/org-1/subscriptions', function(request){
+    var params = JSON.parse(request.requestBody);
+    equal(params.stripe_token, stripeToken, 'stripe token is correct');
+    equal(params.plan, plan, 'plan is correct');
+    equal(params.organization_id, organizationId, 'org id is correct');
+
+    return this.success();
+  });
+
+  var store = this.store();
+
+  var organization = Ember.run(store, 'push', 'organization', {
+    id: organizationId,
+    name: 'Sprocket Co.'
+  });
+
+  var subscription = Ember.run(store, 'createRecord', 'subscription', {
+    organization: organization,
+    stripeToken: 'some-token',
+    plan: 'development'
+  });
+
+  return Ember.run(subscription, 'save').then(function(s){
+    ok(true, 'subscription was saved');
+  });
+});

--- a/tests/unit/welcome/payment-info/route-test.js
+++ b/tests/unit/welcome/payment-info/route-test.js
@@ -1,0 +1,14 @@
+import {
+  moduleFor,
+  test
+} from 'ember-qunit';
+
+moduleFor('route:welcome/payment-info', 'WelcomePaymentInfoRoute', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+test('it exists', function() {
+  var route = this.subject();
+  ok(route);
+});


### PR DESCRIPTION
Introduce a basic payment page (largely unstyled).

Paired with https://github.com/aptible/auth.aptible.com/pull/105, this provides the ability to go from account creation to app/db naming to payment information and the creation of a subscription. For now, the user is directed to `index` after payment info.

@bantic for you to review and merge.

