### PR TITLE
roles/permissions determine visibility of parts of UI

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -4,8 +4,11 @@ import loadInitializers from 'ember/load-initializers';
 import config from './config/environment';
 import { getUrlParameter } from './utils/url-parameters';
 import { replaceLocation } from './utils/location';
+import AuthenticatedRouteMixin from './mixins/routes/authenticated';
 
 Ember.MODEL_FACTORY_INJECTIONS = true;
+
+Ember.Route.reopen(AuthenticatedRouteMixin);
 
 var App = Ember.Application.extend({
   modulePrefix: config.modulePrefix,

--- a/app/application/route.js
+++ b/app/application/route.js
@@ -1,11 +1,5 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
-  beforeModel: function(){
-    if (!this.session.get('isAuthenticated')) {
-      return this.session.fetch('aptible').catch(function(){
-        // no-op; it's ok if we're not logged in
-      });
-    }
-  }
+  requireAuthentication: false
 });

--- a/app/apps/index/route.js
+++ b/app/apps/index/route.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
+  requireAuthentication: true,
+
   model: function(){
     return this.store.find('stack');
   },

--- a/app/apps/index/route.js
+++ b/app/apps/index/route.js
@@ -1,8 +1,6 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
-  requireAuthentication: true,
-
   model: function(){
     return this.store.find('stack');
   },

--- a/app/apps/index/template.hbs
+++ b/app/apps/index/template.hbs
@@ -10,14 +10,16 @@
       </span>
     </h4>
     <ul class="nav nav-pills sub-nav-tabs">
-      <li>
-        {{link-to 'Create App' 'stack.new-app' stack class="new-app-link"}}
-      </li>
-      <li>
-        {{#link-to 'stack.settings' stack data-placement="bottom" data-toggle="tooltip" data-original-title="Account Settings"}}
-          <i class="fa fa-cog"></i>
-        {{/link-to}}
-      </li>
+      {{#aptible-ability scope="manage" user=session.currentUser stack=stack}}
+        <li>
+          {{link-to 'Create App' 'stack.new-app' stack class="new-app-link"}}
+        </li>
+        <li>
+          {{#link-to 'stack.settings' stack data-placement="bottom" data-toggle="tooltip" data-original-title="Account Settings"}}
+            <i class="fa fa-cog"></i>
+          {{/link-to}}
+        </li>
+      {{/aptible-ability}}
     </ul>
     </header>
 

--- a/app/apps/route.js
+++ b/app/apps/route.js
@@ -1,14 +1,8 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
-  beforeModel: function(){
-    var route = this;
-    if (!this.session.get('isAuthenticated')) {
-      return this.session.fetch('aptible').catch(function(){
-        route.transitionTo('login');
-      });
-    }
-  },
+  requireAuthentication: true,
+
   setupController: function(controller, model){
     controller.set('model', model);
     controller.set('sectionTitle', 'Apps');

--- a/app/apps/route.js
+++ b/app/apps/route.js
@@ -1,8 +1,6 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
-  requireAuthentication: true,
-
   setupController: function(controller, model){
     controller.set('model', model);
     controller.set('sectionTitle', 'Apps');

--- a/app/apps/show/route.js
+++ b/app/apps/show/route.js
@@ -1,8 +1,6 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
-  requireAuthentication: true,
-
   setupController: function(controller, model){
     this._super(controller, model);
     controller.set('app', model);

--- a/app/apps/show/route.js
+++ b/app/apps/show/route.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
+  requireAuthentication: true,
+
   setupController: function(controller, model){
     this._super(controller, model);
     controller.set('app', model);

--- a/app/components/aptible-ability/component.js
+++ b/app/components/aptible-ability/component.js
@@ -3,7 +3,7 @@ import can from '../../utils/can';
 
 export default Ember.Component.extend({
   hasAbility: false, // cannot use `isVisible` with `tagName: ''`
-  tagName: '',
+  tagName: '', // tagName must be exactly '' to render this component with no surrounding tag
 
   user: null,
   scope: null,
@@ -15,9 +15,9 @@ export default Ember.Component.extend({
         stack = this.get('stack'),
         component = this;
 
-     Ember.assert("You must provide a user to aptible-ability", user);
-     Ember.assert("You must provide a scope to aptible-ability", scope);
-     Ember.assert("You must provide a stack to aptible-ability", stack);
+     Ember.assert("You must provide a user to aptible-ability", !!user);
+     Ember.assert("You must provide a scope to aptible-ability", !!scope);
+     Ember.assert("You must provide a stack to aptible-ability", !!stack);
 
      can(user, scope, stack).then(function(bool){
        if (component.isDestroyed) { return; }

--- a/app/components/aptible-ability/component.js
+++ b/app/components/aptible-ability/component.js
@@ -1,0 +1,28 @@
+import Ember from 'ember';
+import can from '../../utils/can';
+
+export default Ember.Component.extend({
+  hasAbility: false, // cannot use `isVisible` with `tagName: ''`
+  tagName: '',
+
+  user: null,
+  scope: null,
+  stack: null,
+
+  checkAbility: function(){
+    var user  = this.get('user'),
+        scope = this.get('scope'),
+        stack = this.get('stack'),
+        component = this;
+
+     Ember.assert("You must provide a user to aptible-ability", user);
+     Ember.assert("You must provide a scope to aptible-ability", scope);
+     Ember.assert("You must provide a stack to aptible-ability", stack);
+
+     can(user, scope, stack).then(function(bool){
+       if (component.get('isDestroyed')) { return; }
+
+       component.set('hasAbility', bool);
+     });
+  }.on('didInsertElement')
+});

--- a/app/components/aptible-ability/component.js
+++ b/app/components/aptible-ability/component.js
@@ -20,7 +20,7 @@ export default Ember.Component.extend({
      Ember.assert("You must provide a stack to aptible-ability", stack);
 
      can(user, scope, stack).then(function(bool){
-       if (component.get('isDestroyed')) { return; }
+       if (component.isDestroyed) { return; }
 
        component.set('hasAbility', bool);
      });

--- a/app/components/aptible-ability/template.hbs
+++ b/app/components/aptible-ability/template.hbs
@@ -1,0 +1,3 @@
+{{#if hasAbility}}
+  {{yield}}
+{{/if}}

--- a/app/databases/index/template.hbs
+++ b/app/databases/index/template.hbs
@@ -10,14 +10,16 @@
       </span>
     </h4>
     <ul class="nav nav-pills sub-nav-tabs">
-      <li>
-        {{link-to 'Create Database' 'stack.new-database' stack class="new-database-link"}}
-      </li>
-      <li>
-        <a class="edit-account-link" data-account-id="111" data-placement="bottom" data-toggle="tooltip" title="" data-original-title="Account Settings">
-          <i class="fa fa-cog"></i>
-        </a>
-      </li>
+      {{#aptible-ability user=session.currentUser scope="manage" stack=stack}}
+        <li>
+          {{link-to 'Create Database' 'stack.new-database' stack class="new-database-link"}}
+        </li>
+        <li>
+          <a class="edit-account-link" data-account-id="111" data-placement="bottom" data-toggle="tooltip" title="" data-original-title="Account Settings">
+            <i class="fa fa-cog"></i>
+          </a>
+        </li>
+      {{/aptible-ability}}
     </ul>
     </header>
 

--- a/app/databases/route.js
+++ b/app/databases/route.js
@@ -1,14 +1,6 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
-  beforeModel: function(){
-    var route = this;
-    if (!this.session.get('isAuthenticated')) {
-      return this.session.fetch('aptible').catch(function(){
-        route.transitionTo('login');
-      });
-    }
-  },
   setupController: function(controller, model){
     controller.set('model', model);
     controller.set('sectionTitle', 'Databases');

--- a/app/error/route.js
+++ b/app/error/route.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
+  requireAuthentication: false,
 });

--- a/app/index/route.js
+++ b/app/index/route.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
+  requireAuthentication: false,
+
   redirect: function() {
     var route = this;
 

--- a/app/login/route.js
+++ b/app/login/route.js
@@ -10,6 +10,7 @@ export function buildCredentials(email, password) {
 }
 
 export default Ember.Route.extend({
+  requireAuthentication: false,
 
   model: function() {
     return Ember.Object.create({

--- a/app/mixins/routes/authenticated.js
+++ b/app/mixins/routes/authenticated.js
@@ -1,0 +1,46 @@
+import Ember from 'ember';
+
+// Pre-loading user roles minimizes the number of HTTP
+// requests we have to make later when checking a user's ability
+// to read/manage/etc a stack
+function loadUserRoles(route){
+  var user = route.session.get('currentUser');
+  return user.get('roles');
+}
+
+export default Ember.Mixin.create({
+  requireAuthentication: true, // default to requiring authentication
+
+  beforeModel: function(){
+    if (this.get('requireAuthentication')) {
+      return this._requireAuthentication();
+    } else {
+      return this._checkLogin();
+    }
+  },
+
+  // redirect to 'login' if the user is not signed in
+  _requireAuthentication: function(){
+    var route = this;
+    if (!this.session.get('isAuthenticated')) {
+      return this.session.fetch('aptible').then(function(){
+        return loadUserRoles(route);
+      }).catch(function(){
+        route.transitionTo('login');
+      });
+    } else {
+      return loadUserRoles(route);
+    }
+  },
+
+  // check if the user is signed in, but do nothing if they are not
+  _checkLogin: function(){
+    if (!this.session.get('isAuthenticated')) {
+      return this.session.fetch('aptible').catch(function(){
+        // no-op; it's ok if we are not logged in
+      });
+    } else {
+      return Ember.RSVP.resolve();
+    }
+  }
+});

--- a/app/models/permission.js
+++ b/app/models/permission.js
@@ -1,0 +1,7 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  scope: DS.attr('string'),
+
+  role: DS.belongsTo('role', {async:true})
+});

--- a/app/models/role.js
+++ b/app/models/role.js
@@ -1,0 +1,5 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  privileged: DS.attr('boolean')
+});

--- a/app/models/stack.js
+++ b/app/models/stack.js
@@ -1,12 +1,14 @@
 import DS from 'ember-data';
 
 export default DS.Model.extend({
-  apps: DS.hasMany('apps', {async: true}),
-  databases: DS.hasMany('databases', {async: true}),
   name: DS.attr('string'),
   handle: DS.attr('string'),
   number: DS.attr('string'),
   type: DS.attr('string'),
   syslogHost: DS.attr('string'),
-  syslogPort: DS.attr('string')
+  syslogPort: DS.attr('string'),
+
+  apps: DS.hasMany('apps', {async: true}),
+  databases: DS.hasMany('databases', {async: true}),
+  permissions: DS.hasMany('permissions', {async:true})
 });

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -1,9 +1,19 @@
 import DS from 'ember-data';
+import can from "../utils/can";
 
 export default DS.Model.extend({
-  token: DS.belongsTo('token', {async: true}),
   email: DS.attr('string'),
   name: DS.attr('string'),
   username: DS.attr('string'),
-  password: DS.attr('string')
+  password: DS.attr('string'),
+
+  // relationships
+  token: DS.belongsTo('token', {async: true}),
+  roles: DS.hasMany('role', {async:true}),
+
+  // check ability, returns a promise
+  // e.g.: user.can('manage', stack).then(function(boolean){ ... });
+  can: function(scope, stack){
+    return can(this, scope, stack);
+  }
 });

--- a/app/signup/route.js
+++ b/app/signup/route.js
@@ -2,11 +2,16 @@ import Ember from 'ember';
 import { buildCredentials } from "../login/route";
 
 export default Ember.Route.extend({
+  requireAuthentication: false,
 
   beforeModel: function(){
-    if (this.session.get('isAuthenticated')) {
-      this.replaceWith('index');
-    }
+    var route = this, session = this.session;
+
+    return this._super().then(function(){
+      if (session.get('isAuthenticated')) {
+        route.replaceWith('index');
+      }
+    });
   },
 
   setupController: function(controller){

--- a/app/stack/new-app/route.js
+++ b/app/stack/new-app/route.js
@@ -1,8 +1,6 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
-  requireAuthentication: true,
-
   model: function(){
     var stack = this.modelFor('stack');
     return this.store.createRecord('app', {

--- a/app/stack/new-app/route.js
+++ b/app/stack/new-app/route.js
@@ -1,12 +1,15 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
+  requireAuthentication: true,
+
   model: function(){
     var stack = this.modelFor('stack');
     return this.store.createRecord('app', {
       stack: stack
     });
   },
+
   actions: {
     create: function(){
       var app = this.currentModel;

--- a/app/stack/new-database/route.js
+++ b/app/stack/new-database/route.js
@@ -1,8 +1,6 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
-  requireAuthentication: true,
-
   model: function(){
     var stack = this.modelFor('stack');
     return this.store.createRecord('database', {

--- a/app/stack/new-database/route.js
+++ b/app/stack/new-database/route.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
+  requireAuthentication: true,
+
   model: function(){
     var stack = this.modelFor('stack');
     return this.store.createRecord('database', {

--- a/app/stack/route.js
+++ b/app/stack/route.js
@@ -1,14 +1,7 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
-  beforeModel: function(){
-    var route = this;
-    if (!this.session.get('isAuthenticated')) {
-      return this.session.fetch('aptible').catch(function(){
-        route.transitionTo('login');
-      });
-    }
-  },
+  requireAuthentication: true,
 
   setupController: function(controller, model){
     controller.set('model', model);

--- a/app/stack/route.js
+++ b/app/stack/route.js
@@ -1,8 +1,6 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
-  requireAuthentication: true,
-
   setupController: function(controller, model){
     controller.set('model', model);
 

--- a/app/stack/settings/route.js
+++ b/app/stack/settings/route.js
@@ -1,8 +1,6 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
-  requireAuthentication: true,
-
   setupController: function(controller, model){
     controller.set('stack', model);
   },

--- a/app/stack/settings/route.js
+++ b/app/stack/settings/route.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
+  requireAuthentication: true,
+
   setupController: function(controller, model){
     controller.set('stack', model);
   },

--- a/app/templates/stack/-app-table-row.hbs
+++ b/app/templates/stack/-app-table-row.hbs
@@ -27,12 +27,14 @@
             <span class="button-label">History</span>
           {{/link-to}}
         </li>
-        <li>
-        <a class="destroy-app-link" data-placement="bottom">
-          <i class="fa fa-times-circle-o"></i>
-          <span class="button-label">Deprovision</span>
-        </a>
-        </li>
+        {{#aptible-ability scope="manage" user=session.currentUser stack=stack}}
+          <li>
+          <a class="destroy-app-link" data-placement="bottom">
+            <i class="fa fa-times-circle-o"></i>
+            <span class="button-label">Deprovision</span>
+          </a>
+          </li>
+        {{/aptible-ability}}
       </ul>
     </div>
   </td>

--- a/app/templates/stack/-database-table-row.hbs
+++ b/app/templates/stack/-database-table-row.hbs
@@ -32,12 +32,17 @@
             <span class="button-label">History</span>
           {{/link-to}}
         </li>
-        <li>
-        <a class="destroy-database-link" data-placement="bottom">
-          <i class="fa fa-times-circle-o"></i>
-          <span class="button-label">Deprovision</span>
-        </a>
-        </li>
+
+        {{#aptible-ability user=session.currentUser
+                           scope="manage"
+                           stack=stack}}
+          <li>
+          <a class="destroy-database-link" data-placement="bottom">
+            <i class="fa fa-times-circle-o"></i>
+            <span class="button-label">Deprovision</span>
+          </a>
+          </li>
+        {{/aptible-ability}}
       </ul>
     </div>
   </td>

--- a/app/utils/can.js
+++ b/app/utils/can.js
@@ -1,0 +1,69 @@
+import Ember from 'ember';
+
+var roleUrlRegex = new RegExp('/roles/([a-zA-Z0-9\-]+)$');
+
+function getRoleIdFromPermission(permission){
+  var roleUrl = permission.get('data.links.role');
+
+  if (roleUrl && roleUrlRegex.test(roleUrl)) {
+    var id = roleUrlRegex.exec(roleUrl)[1];
+
+    return Ember.RSVP.resolve(id);
+  } else {
+    return permission.get('role').then(function(role){
+      return role.get('id');
+    });
+  }
+}
+
+export default function can(user, targetScope, stack){
+  var userRoleIds,      // role ids this user has
+      stackPermissions; // permissions this stack has
+
+  if (user._isPrivileged) {
+    // if we already determined that the user is privileged,
+    // can skip the rest of the checks
+    return Ember.RSVP.resolve(true);
+  }
+
+  return user.get('roles').then(function(roles){
+    if (roles.isAny('privileged')) {
+
+      // 'privileged' user can skip the rest of the checks
+      user._isPrivileged = true;
+      return true;
+    }
+
+    userRoleIds = roles.mapBy('id');
+
+    // mapping of role id and permission's scope:
+    // [{roleId: X, scope: Y}, ...]
+    return stack.get('permissions').then(function(permissions){
+      stackPermissions = permissions;
+
+      var stackMappingPromises = stackPermissions.map(function(perm){
+        return getRoleIdFromPermission(perm).then(function(roleId){
+          return {
+            roleId: roleId,
+            scope:  perm.get('scope')
+          };
+        });
+      });
+
+      return Ember.RSVP.all(stackMappingPromises);
+    }).then(function(stackRoleMap){
+
+      return stackRoleMap.any(function(roleMapping){
+
+        // skip if user does not have this role
+        if (!userRoleIds.contains(roleMapping.roleId)) {
+          return;
+        }
+
+        // check if the role has the right permission scope
+        return roleMapping.scope === 'manage' ||
+          roleMapping.scope === targetScope;
+      });
+    });
+  });
+}

--- a/app/verify/route.js
+++ b/app/verify/route.js
@@ -1,15 +1,7 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
-
-  beforeModel: function(){
-    var route = this;
-    if (!this.session.get('isAuthenticated')) {
-      return this.session.fetch('aptible').catch(function(){
-        route.transitionTo('login');
-      });
-    }
-  },
+  requireAuthentication: true,
 
   model: function(params){
     var options = {

--- a/app/verify/route.js
+++ b/app/verify/route.js
@@ -1,8 +1,6 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
-  requireAuthentication: true,
-
   model: function(params){
     var options = {
       verificationCode: params.verification_code,

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "ember-cli-pretender": "^0.3.1",
     "ember-cli-qunit": "0.1.2",
     "ember-data": "1.0.0-beta.12",
-    "ember-data-hal-9000": "git://github.com/201-created/ember-data-hal-9000#8ed5d82a6483ac5f3f6a3af100160435123578cb",
+    "ember-data-hal-9000": "git://github.com/201-created/ember-data-hal-9000#63fc0500a9dd35b6496f0e07940a0d9765efd5b9",
     "ember-export-application-global": "^1.0.0",
     "ember-validations": "^2.0.0-alpha.1",
     "express": "^4.8.5",

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -51,7 +51,8 @@
     "elementTextContains",
     "stubStack",
     "stubStacks",
-    "locationUpdatedTo"
+    "locationUpdatedTo",
+    "expectRequiresAuthentication"
   ],
   "node": false,
   "browser": false,

--- a/tests/acceptance/apps-create-test.js
+++ b/tests/acceptance/apps-create-test.js
@@ -16,6 +16,10 @@ module('Acceptance: App Create', {
   }
 });
 
+test('/stacks/:id/apps/new requires authentication', function(){
+  expectRequiresAuthentication('/stacks/1/apps/new');
+});
+
 test('visit /stacks/1/apps/new', function(){
   expect(2);
 

--- a/tests/acceptance/apps-operations-test.js
+++ b/tests/acceptance/apps-operations-test.js
@@ -13,6 +13,10 @@ module('Acceptance: Apps Operations', {
   }
 });
 
+test('visit /apps/:id/operations requires authentication', function(){
+  expectRequiresAuthentication('/apps/1/operations');
+});
+
 test('visit /apps/:id/operations show operations', function(){
   var appId = 'my-app-id';
 

--- a/tests/acceptance/apps-show-test.js
+++ b/tests/acceptance/apps-show-test.js
@@ -13,6 +13,10 @@ module('Acceptance: Apps Show', {
   }
 });
 
+test('/apps/:id requires authentication', function(){
+  expectRequiresAuthentication('/apps/1');
+});
+
 test('visiting /apps/my-app-id shows basic app info', function() {
   var appId = 'my-app-id';
   var serviceId = 'service-1';

--- a/tests/acceptance/apps-test.js
+++ b/tests/acceptance/apps-test.js
@@ -17,12 +17,8 @@ module('Acceptance: Apps', {
   }
 });
 
-test('visiting /apps when not signed in', function() {
-  visit('/apps');
-
-  andThen(function() {
-    equal(currentPath(), 'login');
-  });
+test('visiting /apps requires authentication', function() {
+  expectRequiresAuthentication('/apps');
 });
 
 test('visiting /apps', function() {

--- a/tests/acceptance/databases-create-test.js
+++ b/tests/acceptance/databases-create-test.js
@@ -13,6 +13,10 @@ module('Acceptance: Database New', {
   }
 });
 
+test('visit /stacks/1/databases/new requires authentication', function(){
+  expectRequiresAuthentication('/stacks/1/databases/new');
+});
+
 test('visit /stacks/1/databases/new shows fields for creating a db', function(){
   var stackId = '1';
   stubStack({id:stackId});

--- a/tests/acceptance/databases-operations-test.js
+++ b/tests/acceptance/databases-operations-test.js
@@ -13,6 +13,10 @@ module('Acceptance: Databases Operations', {
   }
 });
 
+test('visit /databases/:id/operations requires authentication', function(){
+  expectRequiresAuthentication('/databases/1/operations');
+});
+
 test('visit /databases/:id/operations shows operations', function(){
   var dbId = 'my-db-id',
       dbUrl = '/databases/' + dbId,

--- a/tests/acceptance/databases-show-test.js
+++ b/tests/acceptance/databases-show-test.js
@@ -13,6 +13,10 @@ module('Acceptance: Databases Show', {
   }
 });
 
+test('visiting /databases/:id requires authentication', function(){
+  expectRequiresAuthentication('/databases/1');
+});
+
 test('visiting /databases/my-db-id shows the database', function() {
   stubRequest('get', '/databases/my-db-id', function(request){
     return this.success({

--- a/tests/acceptance/databases-test.js
+++ b/tests/acceptance/databases-test.js
@@ -13,6 +13,10 @@ module('Acceptance: Databases', {
   }
 });
 
+test('visiting /databases requires authentication', function(){
+  expectRequiresAuthentication('/databases');
+});
+
 test('visiting /databases', function() {
   signInAndVisit('/databases');
 

--- a/tests/acceptance/service-new-vhost-test.js
+++ b/tests/acceptance/service-new-vhost-test.js
@@ -14,6 +14,10 @@ module('Acceptance: Service New Vhost', {
   }
 });
 
+test('visit /services/:id/vhosts/new requires authentication', function(){
+  expectRequiresAuthentication('/services/1/vhosts/new');
+});
+
 test('visit /services/:id/vhosts/new', function(){
   var serviceId = 'service-1';
 

--- a/tests/acceptance/stack-settings-test.js
+++ b/tests/acceptance/stack-settings-test.js
@@ -14,6 +14,10 @@ module('Acceptance: Stack Settings', {
   }
 });
 
+test('visit /stacks/1/settings requires authentication', function(){
+  expectRequiresAuthentication('/stacks/1/settings');
+});
+
 test('visit /stacks/:id/settings', function(){
   var stackName = 'Cool Stack';
   stubStack({id:1, name:stackName});

--- a/tests/acceptance/verification-test.js
+++ b/tests/acceptance/verification-test.js
@@ -13,11 +13,8 @@ module('Acceptance: Verification', {
   }
 });
 
-test('visiting /verify/some-code requires auth', function() {
-  visit('/verify/some-code');
-  andThen(function(){
-    equal(currentPath(), 'login');
-  });
+test('visiting /verify/some-code requires authentication', function() {
+  expectRequiresAuthentication('/verify/some-code');
 });
 
 test('visiting /verify/some-code creates verification', function() {

--- a/tests/helpers/aptible-helpers.js
+++ b/tests/helpers/aptible-helpers.js
@@ -7,13 +7,27 @@ Ember.Test.registerAsyncHelper('signIn', function(app){
   var sm = session.get('stateMachine');
 
   Ember.run(function(){
+    var store = app.__container__.lookup('store:main');
+    var user = store.push('user', {
+      id: 'user1',
+      name: 'stubbed user'
+    });
     sm.transitionTo('authenticated');
+    session.set('content.currentUser', user);
   });
 });
 
 Ember.Test.registerAsyncHelper('signInAndVisit', function(app, url){
   signIn();
   visit(url);
+});
+
+Ember.Test.registerAsyncHelper('expectRequiresAuthentication', function(app, url){
+  visit(url);
+
+  andThen(function(){
+    equal(currentPath(), 'login');
+  });
 });
 
 Ember.Test.registerAsyncHelper('locationUpdatedTo', function(app, url){

--- a/tests/unit/components/aptible-ability-test.js
+++ b/tests/unit/components/aptible-ability-test.js
@@ -1,0 +1,25 @@
+import {
+  moduleForComponent,
+  test
+} from 'ember-qunit';
+
+moduleForComponent('aptible-ability', 'AptibleAbilityComponent', {
+  // specify the other units that are required for this test
+  // needs: ['component:foo', 'helper:bar']
+});
+
+test('it renders', function() {
+  ok(true, 'FIXME');
+
+  /*
+  expect(2);
+
+  // creates the component instance
+  var component = this.subject();
+  equal(component._state, 'preRender');
+
+  // appends the component to the page
+  this.append();
+  equal(component._state, 'inDOM');
+  */
+});

--- a/tests/unit/models/app-test.js
+++ b/tests/unit/models/app-test.js
@@ -8,13 +8,16 @@ import Ember from 'ember';
 
 moduleForModel('app', 'App', {
   needs: [
-    'adapter:app',
-    'serializer:application',
     'model:service',
     'model:stack',
     'model:database',
     'model:vhost',
-    'model:operation'
+    'model:operation',
+    'model:permission',
+    'model:role',
+
+    'adapter:app',
+    'serializer:application'
   ]
 });
 

--- a/tests/unit/models/database-test.js
+++ b/tests/unit/models/database-test.js
@@ -13,6 +13,9 @@ moduleForModel('database', 'Database', {
     'model:app',
     'model:service',
     'model:operation',
+    'model:permission',
+    'model:role',
+
     'adapter:database',
     'serializer:application'
   ]

--- a/tests/unit/models/operation-test.js
+++ b/tests/unit/models/operation-test.js
@@ -11,6 +11,9 @@ moduleForModel('operation', 'Operation', {
     'model:app',
     'model:stack',
     'model:database',
+    'model:permission',
+    'model:role',
+
     'adapter:operation',
     'serializer:application'
   ]

--- a/tests/unit/models/permission-test.js
+++ b/tests/unit/models/permission-test.js
@@ -3,9 +3,14 @@ import {
   test
 } from 'ember-qunit';
 
-moduleForModel('user', 'User', {
+moduleForModel('permission', 'Permission', {
   // Specify the other units that are required for this test.
-  needs: ['model:token', 'model:role']
+  needs: [
+    'model:role',
+    'model:stack',
+    'model:app',
+    'model:database'
+  ]
 });
 
 test('it exists', function() {

--- a/tests/unit/models/role-test.js
+++ b/tests/unit/models/role-test.js
@@ -3,9 +3,9 @@ import {
   test
 } from 'ember-qunit';
 
-moduleForModel('user', 'User', {
+moduleForModel('role', 'Role', {
   // Specify the other units that are required for this test.
-  needs: ['model:token', 'model:role']
+  needs: []
 });
 
 test('it exists', function() {

--- a/tests/unit/models/stack-test.js
+++ b/tests/unit/models/stack-test.js
@@ -12,6 +12,9 @@ moduleForModel('stack', 'Stack', {
     'model:app',
     'model:service',
     'model:operation',
+    'model:permission',
+    'model:role',
+
     'adapter:application',
     'serializer:application'
   ]

--- a/tests/unit/torii-adapters/aptible-test.js
+++ b/tests/unit/torii-adapters/aptible-test.js
@@ -12,7 +12,13 @@ import Ember from "ember";
 var originalWrite, originalRead;
 
 moduleFor('torii-adapter:aptible', 'Torii Adapter: Aptible', {
-  needs: ['model:token', 'model:user', 'adapter:application', 'serializer:application'],
+  needs: [
+    'model:token',
+    'model:user',
+    'model:role',
+    'adapter:application',
+    'serializer:application'
+  ],
   setup: function(container){
     DS._setupContainer(container);
     originalWrite = storage.write;
@@ -68,7 +74,11 @@ test('adapter stores the auth token in storage', function(){
       equal(wroteKey, config.authTokenKey, 'writes to config.authTokenKey');
       equal(wroteVal, token, 'writes token value');
       equal(auth.token, token, 'sets token on auth');
-      ok(resultForSession.currentUser, 'sets currentUser on session');
+
+      // QUnit will hang forever if we don't explicitly turn this into
+      // a boolean, because the currentUser object (maybe) has some recursive
+      // structure that foils QUnit's eager generation of its failure message
+      ok(!!resultForSession.currentUser, 'sets currentUser on session');
       equal(Ember.get(resultForSession, 'currentUser.username'), userEmail, 'user email is from the API');
     }, function(e){
       ok(false, "Unexpected error: "+e);

--- a/tests/unit/utils/can-test.js
+++ b/tests/unit/utils/can-test.js
@@ -1,0 +1,304 @@
+import {
+  moduleForModel,
+  test
+} from 'ember-qunit';
+import config from "../../../config/environment";
+import { stubRequest } from '../../helpers/fake-server';
+import DS from "ember-data";
+import Ember from "ember";
+import can from "../../../utils/can";
+
+var store;
+
+moduleForModel('user', 'Utils - #can', {
+  needs: [
+    'model:role',
+    'model:token',
+    'model:app',
+    'model:database',
+    'model:service',
+    'model:operation',
+    'model:stack',
+    'model:permission',
+    'adapter:application',
+    'serializer:application'
+  ],
+  setup: function(container){
+    store = container.lookup('store:main');
+  },
+  teardown: function(){
+    Ember.run(store, 'destroy');
+  }
+});
+
+test('it exists', function(){
+  ok(!!can, 'it exists');
+});
+
+test('user and stack have same role, stack\'s permission has "manage" scope', function(){
+  var user, userRole, stack, stackPermission;
+
+  Ember.run(function(){
+    user     = store.push('user', {id:'u1', roles:['r1']});
+    userRole = store.push('role', {id:'r1'});
+
+    stack    = store.push('stack', {id:'s1', permissions:['p1']});
+    stackPermission = store.push('permission', {id:'p1', scope:'manage', role:'r1'});
+  });
+
+  return Ember.run(function(){
+    return can(user, 'manage', stack).then(function(res){
+      ok(res, 'user can manage stack');
+
+      return can(user, 'read', stack);
+    }).then(function(res){
+      ok(res, 'user can read stack');
+    });
+  });
+});
+
+test('user and stack have same role, stack\'s permission has "read" scope', function(){
+  var user, userRole, stack, stackPermission;
+
+  Ember.run(function(){
+    user     = store.push('user', {id:'u1', roles:['r1']});
+    userRole = store.push('role', {id:'r1'});
+
+    stack    = store.push('stack', {id:'s1', permissions:['p1']});
+    stackPermission = store.push('permission', {id:'p1', scope:'read', role:'r1'});
+  });
+
+  return Ember.run(function(){
+    return can(user, 'manage', stack).then(function(res){
+      ok(!res, 'user can not manage stack');
+
+      return can(user, 'read', stack);
+    }).then(function(res){
+      ok(res, 'user can read stack');
+    });
+  });
+});
+
+test('user and stack do not have same role', function(){
+  var user, userRole, stack, stackPermission, stackRole;
+
+  Ember.run(function(){
+    user     = store.push('user', {id:'u1', roles:['r1']});
+    userRole = store.push('role', {id:'r1'});
+
+    stack    = store.push('stack', {id:'s1', permissions:['p1']});
+    stackPermission = store.push('permission', {id:'p1', scope:'read', role:'r2'});
+    stackRole = store.push('role', {id:'r2'});
+  });
+
+  return Ember.run(function(){
+    return can(user, 'manage', stack).then(function(res){
+      ok(!res, 'user can not manage stack');
+
+      return can(user, 'read', stack);
+    }).then(function(res){
+      ok(!res, 'user can not read stack');
+    });
+  });
+});
+
+test('user has privileged role', function(){
+  var user, userRole, stack;
+
+  Ember.run(function(){
+    user     = store.push('user', {id:'u1', roles:['r1']});
+    userRole = store.push('role', {id:'r1', privileged:true});
+
+    stack    = store.push('stack', {id:'s1', permissions:['p1']});
+  });
+
+  return Ember.run(function(){
+    return can(user, 'manage', stack).then(function(res){
+      ok(res, 'privileged user can manage stack');
+
+      return can(user, 'read', stack);
+    }).then(function(res){
+      ok(res, 'privileged user can read stack');
+    });
+  });
+});
+
+test('user has multiple roles, some match stack\'s role', function(){
+  var user,
+      userRole1, userRole2,
+      stack,
+      stackPermission;
+
+  Ember.run(function(){
+    user      = store.push('user', {id:'u1', roles:['r1','r2']});
+    userRole1 = store.push('role', {id:'r1'});
+    userRole2 = store.push('role', {id:'r2'});
+
+    stack           = store.push('stack',      {id:'s1', permissions:['p1']});
+    stackPermission = store.push('permission', {id:'p1', scope:'read', role: 'r2'});
+  });
+
+  return Ember.run(function(){
+    return can(user, 'manage', stack).then(function(res){
+      ok(!res, 'user can not manage stack');
+
+      return can(user, 'read', stack);
+    }).then(function(res){
+      ok(res, 'user can read stack');
+    });
+  });
+});
+
+test('stack has multiple permissions, some match user\'s role', function(){
+  var user,
+      userRole,
+      stack,
+      stackPermission1,
+      stackPermission2;
+
+  Ember.run(function(){
+    user      = store.push('user', {id:'u1', roles:['r1']});
+    userRole  = store.push('role', {id:'r1'});
+
+    stack            = store.push('stack',      {id:'s1', permissions:['p1','p2']});
+    stackPermission1 = store.push('permission', {id:'p1', scope:'read', role: 'r1'});
+    stackPermission2 = store.push('permission', {id:'p2', scope:'read', role: 'r2'});
+    var otherRole    = store.push('role', {id:'r2'});
+  });
+
+  return Ember.run(function(){
+    return can(user, 'manage', stack).then(function(res){
+      ok(!res, 'user can not manage stack');
+
+      return can(user, 'read', stack);
+    }).then(function(res){
+      ok(res, 'user can read stack');
+    });
+  });
+});
+
+test('with manage permission scope, user can do anything', function(){
+  var user,
+      userRole,
+      stack,
+      stackPermission;
+
+  Ember.run(function(){
+    user      = store.push('user', {id:'u1', roles:['r1']});
+    userRole = store.push('role', {id:'r1'});
+
+    stack           = store.push('stack',      {id:'s1', permissions:['p1']});
+    stackPermission = store.push('permission', {id:'p1', scope:'manage', role: 'r1'});
+  });
+
+  return Ember.run(function(){
+    return can(user, 'manage', stack).then(function(res){
+      ok(res, 'user can manage stack');
+
+      return can(user, 'read', stack);
+    }).then(function(res){
+      ok(res, 'user can read stack');
+
+      return can(user, 'glorp', stack);
+    }).then(function(res){
+      ok(res, 'user can glorp stack');
+    });
+  });
+});
+
+test('when permission data includes role links, do not fetch roles, just use derived ids', function(){
+  var user,
+      userRole,
+      stack,
+      stackPermission;
+
+  Ember.run(function(){
+    user      = store.push('user', {id:'u1', roles:['abc-DEF-123']});
+    userRole = store.push('role', {id:'abc-DEF-123'});
+
+    stack           = store.push('stack',      {id:'s1', permissions:['p1']});
+    stackPermission = store.push('permission', {id:'p1', scope:'manage', links: {role: '/roles/abc-DEF-123'}});
+  });
+
+  stubRequest('get', '/roles/abc-DEF-123', function(){
+    ok(false, 'should not fetch role by url');
+  });
+
+  return Ember.run(function(){
+    return can(user, 'manage', stack).then(function(){
+      ok(true, 'did not fetch role by url');
+    });
+  });
+});
+
+test('#can fetches data when it is not in the store', function(){
+  expect(5);
+
+  var user,
+      userRole,
+      stack,
+      stackPermission;
+
+  stubRequest('get', '/users/u1', function(){
+    ok(true, 'requests user by id');
+
+    return this.success({
+      id: 'u1',
+      _links: {
+        self: { href: '/users/u1' },
+        roles: { href: '/users/u1/roles'}
+      }
+    });
+  });
+
+  stubRequest('get', '/users/u1/roles', function(){
+    ok(true, 'requests user roles');
+
+    return this.success({
+      _embedded: {
+        roles: [{
+          id: 'abc-DEF-123',
+        }]
+      }
+    });
+  });
+
+  stubRequest('get', '/accounts/s1', function(){
+    ok(true, 'requests stacks by id');
+
+    return this.success({
+      id: 's1',
+      _embedded: {
+        permissions: [{
+          id: 'p1',
+          scope: 'read',
+          _links: {
+            role: { href: '/roles/abc-DEF-123' }
+          }
+        }]
+      }
+    });
+  });
+
+  stubRequest('get', '/roles/abc-DEF-123', function(){
+    ok(false, 'should not request role by url');
+  });
+
+  return Ember.run(function(){
+    return Ember.RSVP.hash({
+      user:  store.find('user', 'u1'),
+      stack: store.find('stack', 's1')
+    }).then(function(results){
+      user = results.user;
+      stack = results.stack;
+
+      return can(user, 'manage', stack);
+    }).then(function(bool){
+      ok(!bool, 'user cannot manage stack');
+
+      return can(user, 'read', stack);
+    }).then(function(bool){
+      ok(bool, 'user can read stack');
+    });
+  });
+});


### PR DESCRIPTION
__Do not merge__

 * create role and permission models
 * {{aptible-ability}} component
 * update version of ember-data-hal-adapter
 * change test helper `signIn` to push a stubbed current user into the store and set on session

Still to do

  * [x] fix failing tests at travis-ci
  * [x] get [changes to hal adapter merged](https://github.com/201-created/ember-data-hal-9000/pull/2)
  * [x] tests for User.can, {{aptible-ability}}
  * [x] add authenticated route that preloads permissions/roles
  * [x] determine if we can avoid loading roles from stack permissions since the API gives their URLs already
  * [x] PR changes to api to embed permissions in stacks (https://github.com/aptible/api.aptible.com/pull/147)

refs #42 #28