### PR TITLE
Pagination for apps and db operations pages

### DIFF
--- a/app/adapters/operation.js
+++ b/app/adapters/operation.js
@@ -3,6 +3,22 @@ import buildURLWithPrefixMap from '../utils/build-url-with-prefix-map';
 
 export default ApplicationAdapter.extend({
   buildURL: buildURLWithPrefixMap({
-    'databases': 'database.id'
-  })
+    'databases': 'database.id',
+    'apps':      'app.id'
+  }),
+
+  findQuery: function(store, type, query){
+    var url;
+    if (query.app) {
+      url = this.buildURL(type.typeKey, null, {app: query.app});
+      delete query.app;
+    } else if (query.database) {
+      url = this.buildURL(type.typeKey, null, {database: query.database});
+      delete query.database;
+    } else {
+      url = this.buildURL(type.typeKey);
+    }
+
+    return this.ajax(url, 'GET', {data:query});
+  }
 });

--- a/app/apps/show/operations/controller.js
+++ b/app/apps/show/operations/controller.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
+import Paginated from 'diesel/mixins/controllers/paginated';
 
-export default Ember.Controller.extend({
+export default Ember.Controller.extend(Paginated, {
   operationResourceType: 'app'
 });

--- a/app/apps/show/operations/route.js
+++ b/app/apps/show/operations/route.js
@@ -1,16 +1,19 @@
 import Ember from 'ember';
+import Paginated from "diesel/mixins/routes/paginated";
 
-export default Ember.Route.extend({
-  model: function(){
+export default Ember.Route.extend(Paginated, {
+  model: function(params, transition){
     var app = this.modelFor('apps.show');
+    var page = parseInt(transition.queryParams.page || 1, 10);
 
-    return app.get('operations');
+    return this.store.find('operation', {app:app, page:page});
   },
 
   setupController: function(controller, model){
-    this._super(controller, model);
-
-    controller.set('app', this.modelFor('apps.show'));
+    var app = this.modelFor('apps.show');
     controller.set('operations', model);
+    controller.set('paginatedResourceOwner', app);
+
+    this.setPaginationMeta(controller, 'operation');
   }
 });

--- a/app/apps/show/operations/route.js
+++ b/app/apps/show/operations/route.js
@@ -2,9 +2,9 @@ import Ember from 'ember';
 import Paginated from "diesel/mixins/routes/paginated";
 
 export default Ember.Route.extend(Paginated, {
-  model: function(params, transition){
+  model: function(params){
     var app = this.modelFor('apps.show');
-    var page = parseInt(transition.queryParams.page || 1, 10);
+    var page = params.currentPage || 1;
 
     return this.store.find('operation', {app:app, page:page});
   },

--- a/app/components/aptible-ability/component.js
+++ b/app/components/aptible-ability/component.js
@@ -1,5 +1,4 @@
 import Ember from 'ember';
-import can from '../../utils/can';
 
 export default Ember.Component.extend({
   hasAbility: false, // cannot use `isVisible` with `tagName: ''`
@@ -19,7 +18,7 @@ export default Ember.Component.extend({
      Ember.assert("You must provide a scope to aptible-ability", !!scope);
      Ember.assert("You must provide a stack to aptible-ability", !!stack);
 
-     can(user, scope, stack).then(function(bool){
+     user.can(scope, stack).then(function(bool){
        if (component.isDestroyed) { return; }
 
        component.set('hasAbility', bool);

--- a/app/components/aptible-pagination/component.js
+++ b/app/components/aptible-pagination/component.js
@@ -1,0 +1,28 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  currentPage: 1,
+  totalCount: 0,
+  perPage: 0,
+
+  hasPrev: function(){
+     return this.get('currentPage') > 1;
+  }.property('currentPage'),
+
+  hasNext: function(){
+    var currentPage = this.get('currentPage'),
+        totalCount  = this.get('totalCount'),
+        perPage     = this.get('perPage');
+
+     return (totalCount / perPage) > currentPage;
+  }.property('currentPage','totalCount','perPage'),
+
+  actions: {
+    nextPage: function(currentPage){
+      this.sendAction('nextPage', currentPage);
+    },
+    prevPage: function(currentPage){
+      this.sendAction('prevPage', currentPage);
+    }
+  }
+});

--- a/app/components/aptible-pagination/template.hbs
+++ b/app/components/aptible-pagination/template.hbs
@@ -1,0 +1,24 @@
+<div class="pagination">
+  <div {{bind-attr class=":prev hasPrev::disabled"}}>
+    {{#if hasPrev}}
+      <a {{action 'prevPage' currentPage}}>
+        Prev
+      </a>
+    {{else}}
+      Prev
+    {{/if}}
+  </div>
+  <div class="current">
+    {{currentPage}}
+  </div>
+
+  <div {{bind-attr class=":next hasNext::disabled"}}>
+    {{#if hasNext}}
+      <a {{action 'nextPage' currentPage}}>
+        Next
+      </a>
+    {{else}}
+      Next
+    {{/if}}
+  </div>
+</div>

--- a/app/databases/show/operations/controller.js
+++ b/app/databases/show/operations/controller.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
+import Paginated from 'diesel/mixins/controllers/paginated';
 
-export default Ember.Controller.extend({
+export default Ember.Controller.extend(Paginated, {
   operationResourceType: 'database'
 });

--- a/app/databases/show/operations/route.js
+++ b/app/databases/show/operations/route.js
@@ -1,14 +1,19 @@
 import Ember from 'ember';
+import Paginated from "diesel/mixins/routes/paginated";
 
-export default Ember.Route.extend({
-  model: function(){
+export default Ember.Route.extend(Paginated, {
+  model: function(params, transition){
     var db = this.modelFor('databases.show');
+    var page = parseInt(transition.queryParams.page || 1, 10);
 
-    return db.get('operations');
+    return this.store.find('operation', {database:db, page:page});
   },
 
   setupController: function(controller, model){
-    controller.set('db', this.modelFor('databases.show'));
+    var db = this.modelFor('databases.show');
     controller.set('operations', model);
+    controller.set('paginatedResourceOwner', db);
+
+    this.setPaginationMeta(controller, 'operation');
   }
 });

--- a/app/databases/show/operations/route.js
+++ b/app/databases/show/operations/route.js
@@ -2,9 +2,9 @@ import Ember from 'ember';
 import Paginated from "diesel/mixins/routes/paginated";
 
 export default Ember.Route.extend(Paginated, {
-  model: function(params, transition){
+  model: function(params){
     var db = this.modelFor('databases.show');
-    var page = parseInt(transition.queryParams.page || 1, 10);
+    var page = params.currentPage || 1;
 
     return this.store.find('operation', {database:db, page:page});
   },

--- a/app/mixins/controllers/paginated.js
+++ b/app/mixins/controllers/paginated.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export default Ember.Mixin.create({
+  queryParams: [{currentPage: {as:'page', refreshModel:true}}],
+
+  currentPage: 1
+});

--- a/app/mixins/routes/paginated.js
+++ b/app/mixins/routes/paginated.js
@@ -1,0 +1,39 @@
+import Ember from 'ember';
+
+export default Ember.Mixin.create({
+  setPaginationMeta: function(controller, type){
+    var meta = this.store.metadataFor(type);
+
+    controller.set('currentPage', meta.current_page);
+    controller.set('totalCount', meta.total_count);
+    controller.set('perPage', meta.per_page);
+  },
+
+  actions: {
+    goToPage: function(page){
+      var controller = this.controller;
+      var store = this.store;
+      var route = this;
+      var query = { page: page };
+
+      var paginatedResourceOwner = this.controller.get('paginatedResourceOwner');
+      query[ paginatedResourceOwner.constructor.typeKey ] = paginatedResourceOwner;
+
+      store.find('operation', query).then(function(operations){
+        controller.set('operations', operations);
+
+        route.setPaginationMeta(controller, 'operation');
+      });
+    },
+
+    prevPage: function(currentPage){
+      var prevPage = Math.min(currentPage - 1, 1);
+      return this.send('goToPage', prevPage);
+    },
+
+    nextPage: function(currentPage){
+      var nextPage = parseInt(currentPage,10) + 1;
+      this.send('goToPage', nextPage);
+    }
+  }
+});

--- a/app/templates/shared/operations/-audit-history.hbs
+++ b/app/templates/shared/operations/-audit-history.hbs
@@ -38,6 +38,16 @@
                     </tr>
                   {{/each}}
                 </tbody>
+
+                <tfoot>
+                  <tr><td>
+                    {{aptible-pagination currentPage=currentPage
+                                         totalCount=totalCount
+                                         perPage=perPage
+                                         nextPage="nextPage"
+                                         prevPage="prevPage" }}
+                  </td></tr>
+                </tfoot>
               </table>
             </header>
           </div>

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "ember-cli-pretender": "^0.3.1",
     "ember-cli-qunit": "0.1.2",
     "ember-data": "1.0.0-beta.12",
-    "ember-data-hal-9000": "0.1.1",
+    "ember-data-hal-9000": "0.1.3",
     "ember-export-application-global": "^1.0.0",
     "ember-validations": "^2.0.0-alpha.1",
     "express": "^4.8.5",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "ember-cli-pretender": "^0.3.1",
     "ember-cli-qunit": "0.1.2",
     "ember-data": "1.0.0-beta.12",
-    "ember-data-hal-9000": "git://github.com/201-created/ember-data-hal-9000#63fc0500a9dd35b6496f0e07940a0d9765efd5b9",
+    "ember-data-hal-9000": "0.1.1",
     "ember-export-application-global": "^1.0.0",
     "ember-validations": "^2.0.0-alpha.1",
     "express": "^4.8.5",

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -52,9 +52,11 @@
     "stubStack",
     "stubStacks",
     "locationUpdatedTo",
-    "expectRequiresAuthentication",
     "stubOrganizations",
-    "locationUpdatedTo"
+    "expectRequiresAuthentication",
+    "expectPaginationElements",
+    "clickNextPageLink",
+    "clickPrevPageLink"
   ],
   "node": false,
   "browser": false,

--- a/tests/helpers/aptible-helpers.js
+++ b/tests/helpers/aptible-helpers.js
@@ -34,6 +34,39 @@ Ember.Test.registerAsyncHelper('locationUpdatedTo', function(app, url){
   equal(locationHistory.last, url, 'window.location updated to expected URL');
 });
 
+Ember.Test.registerAsyncHelper('clickNextPageLink', function(app){
+  click('.pagination .next a');
+});
+
+Ember.Test.registerAsyncHelper('clickPrevPageLink', function(app){
+  click('.pagination .prev a');
+});
+
+Ember.Test.registerHelper('expectPaginationElements', function(app, options){
+  options = options || {};
+
+  var pagination = find('.pagination');
+  ok(pagination.length, 'has pagination');
+
+  var currentPage = options.currentPage || 1;
+  var currentPageEl = find('.current:contains('+currentPage+')', pagination);
+  ok(currentPageEl.length, 'has current page: '+currentPage);
+
+  var prevPage = find('.prev', pagination);
+  if (options.prevEnabled){
+    ok(prevPage.length && !prevPage.hasClass('disabled'), 'enabled prev div');
+  } else {
+    ok(prevPage.length && prevPage.hasClass('disabled'), 'disabled prev div');
+  }
+
+  var nextPage = find('.next', pagination);
+  if (options.nextDisabled){
+    ok(nextPage.length && nextPage.hasClass('disabled'), 'disabled nextPage page div');
+  } else {
+    ok(nextPage.length && !nextPage.hasClass('disabled'), 'enabled nextPage page div');
+  }
+});
+
 Ember.Test.registerHelper('equalElementText', function(app, node, expectedText){
   equal(node.text().trim(), expectedText, "Element's text did not match expected value");
 });

--- a/tests/helpers/shared-tests.js
+++ b/tests/helpers/shared-tests.js
@@ -1,0 +1,188 @@
+import { stubRequest } from '../helpers/fake-server';
+
+export function paginatedResourceQueryParamsPage2Test(options){
+  var resourceId = '1';
+  var resourceUrl = '/' + options.resourceType + '/' + resourceId;
+
+  var paginatedResourceUrl = resourceUrl + '/operations';
+
+  stubRequest('get', resourceUrl, function(request){
+    return this.success({ id: resourceId });
+  });
+
+  stubRequest('get', paginatedResourceUrl, function(request){
+    equal(request.queryParams.page, 2);
+
+    return this.success({
+      current_page: 2,
+      per_page: 1,
+      total_count: 2,
+      _embedded: {
+        operations: [{id: 'op-2', type: 'configure'}]
+      }
+    });
+  });
+
+  signInAndVisit(paginatedResourceUrl + '?page=2');
+  andThen(function(){
+    expectPaginationElements(
+      {currentPage:2, prevEnabled:true, nextDisabled:true});
+  });
+}
+
+export function paginatedResourceUpdatesQueryParamsTest(options){
+  var resourceId = '1';
+  var resourceUrl = '/' + options.resourceType + '/' + resourceId;
+
+  var paginatedResourceUrl = resourceUrl + '/operations';
+
+  stubRequest('get', resourceUrl, function(request){
+    return this.success({ id: resourceId });
+  });
+
+  stubRequest('get', paginatedResourceUrl, function(request){
+    var page = parseInt(request.queryParams.page, 10);
+
+    return this.success({
+      current_page: page,
+      per_page: 1,
+      total_count: 2,
+      _embedded: {
+        operations: [ {id: 'op-' + page, type:'deploy'} ]
+      }
+    });
+  });
+
+  signInAndVisit(paginatedResourceUrl);
+
+  andThen(function(){
+    equal(currentURL(), paginatedResourceUrl);
+
+    clickNextPageLink();
+  });
+
+  andThen(function(){
+    equal(currentURL(), paginatedResourceUrl + '?page=2');
+  });
+}
+
+export function resourceOperationsTest(options){
+  var resourceId = '1';
+  var resourceUrl = '/' + options.resourceType + '/' + resourceId;
+  var expectedHeader = options.expectedHeader;
+
+  var paginatedResourceUrl = resourceUrl + '/operations';
+
+  stubRequest('get', resourceUrl, function(request){
+    return this.success({ id: resourceId });
+  });
+
+  stubRequest('get', paginatedResourceUrl, function(request){
+    return this.success({
+      current_page: 1,
+      per_page: 20,
+      total_count: 5*20,
+      _embedded: {
+        operations: [{
+          id: 1,
+          type: 'configure',
+          status: 'succeeded',
+          createdAt: '2014-11-19T00:15:33.836Z',
+          userName: 'Frank Macreery',
+          userEmail: 'frank@aptible.com'
+        }, {
+          id: 2,
+          type: 'deploy',
+          status: 'succeeded',
+          createdAt: '2014-11-19T00:15:33.836Z',
+          userName: 'Frank Macreery',
+          userEmail: 'frank@aptible.com'
+        }, {
+          id: 3,
+          type: 'execute',
+          status: 'failed',
+          createdAt: '2014-11-19T00:15:33.836Z',
+          userName: 'Frank Macreery',
+          userEmail: 'frank@aptible.com'
+        }]
+      }
+    });
+  });
+
+  signInAndVisit(paginatedResourceUrl);
+
+  andThen(function(){
+    var header = find('header:contains(' + expectedHeader + ')');
+    ok(header.length, 'has header');
+
+    var operationsContainer = find('.operations');
+    var operations = find('.operation', operationsContainer);
+
+    equal(operations.length, 3, 'has 3 operations');
+
+    ['Configure', 'Deploy', 'Execute'].forEach(function(type){
+      ok(find('.operation-type:contains(' + type + ')').length,
+         'has capitalized operation type: ' + type);
+    });
+
+    ['Succeeded', 'Failed'].forEach(function(type){
+      ok(find('.operation-status:contains(' + type + ')').length,
+         'has capitalized operation status: ' + type);
+    });
+
+    var operationCreatedBy = find('.operation-created-by:contains(Frank Macreery)');
+    ok(operationCreatedBy.length, 'has operation created by username');
+
+    expectPaginationElements();
+  });
+}
+
+export function paginatedResourceTest(options){
+  var resourceId = '1';
+  var resourceUrl = '/' + options.resourceType + '/' + resourceId;
+
+  var paginatedResourceUrl = resourceUrl + '/operations';
+  var requestNum = 0;
+
+  var ops = [
+    {id: 1, type: 'configure'},
+    {id: 2, type: 'deploy'},
+  ];
+  var orderedResponses = [
+    {page: 1, op: ops[0] },
+    {page: 2, op: ops[1] },
+    {page: 1, op: ops[0] }
+  ];
+
+  expect(orderedResponses.length);
+
+  stubRequest('get', resourceUrl, function(request){
+    return this.success({
+      id: resourceId
+    });
+  });
+
+  stubRequest('get', paginatedResourceUrl, function(request){
+    requestNum++;
+
+    if (requestNum > orderedResponses.length) {
+      ok(false, 'Too many requests: ' + requestNum);
+    }
+
+    var response = orderedResponses[ requestNum - 1];
+    equal(request.queryParams.page, response.page, 'request #' + requestNum + ' has correct page');
+
+    return this.success({
+      current_page: response.page,
+      per_page: 1,
+      total_count: ops.length,
+      _embedded: {
+        operations: [ response.op ]
+      }
+    });
+  });
+
+  signInAndVisit(paginatedResourceUrl);
+  clickNextPageLink();
+  clickPrevPageLink();
+}

--- a/tests/unit/components/aptible-ability-test.js
+++ b/tests/unit/components/aptible-ability-test.js
@@ -3,23 +3,27 @@ import {
   test
 } from 'ember-qunit';
 
+import Ember from 'ember';
+
 moduleForComponent('aptible-ability', 'AptibleAbilityComponent', {
   // specify the other units that are required for this test
   // needs: ['component:foo', 'helper:bar']
 });
 
 test('it renders', function() {
-  ok(true, 'FIXME');
-
-  /*
   expect(2);
 
   // creates the component instance
-  var component = this.subject();
+  var component = this.subject({
+    user: {
+      can: Ember.RSVP.resolve
+    },
+    scope: 'read',
+    stack: {}
+  });
   equal(component._state, 'preRender');
 
   // appends the component to the page
   this.append();
   equal(component._state, 'inDOM');
-  */
 });

--- a/tests/unit/components/aptible-pagination-test.js
+++ b/tests/unit/components/aptible-pagination-test.js
@@ -1,0 +1,66 @@
+import {
+  moduleForComponent,
+  test
+} from 'ember-qunit';
+
+import Ember from 'ember';
+
+moduleForComponent('aptible-pagination', 'AptiblePaginationComponent', {
+  // specify the other units that are required for this test
+  // needs: ['component:foo', 'helper:bar']
+});
+
+test('next page div is disabled when there is no next page', function() {
+  var component = this.subject({
+    hasNext: true
+  });
+
+  var element = this.append();
+
+  var next = element.find('.pagination .next');
+  ok(next.length, 'has .next div');
+
+  ok(!next.hasClass('disabled'), 'next is not disabled');
+
+  Ember.run(component, 'set', 'hasNext', false);
+
+  ok(next.hasClass('disabled'), 'next is disabled');
+});
+
+test('prev page div is disabled when there is no prev page', function() {
+  var component = this.subject({
+    hasPrev: false
+  });
+
+  var element = this.append();
+
+  var prev = element.find('.pagination .prev');
+  ok(prev.length, 'has .prev div');
+
+  ok(prev.hasClass('disabled'), 'prev is disabled');
+
+  Ember.run(component, 'set', 'hasPrev', true);
+
+  ok(!prev.hasClass('disabled'), 'prev is not disabled');
+});
+
+test('hasNext is calculated from currentPage, totalCount and perPage', function(){
+  var component = this.subject({
+    currentPage: 1,
+    totalCount: 5,
+    perPage: 2
+  });
+
+  ok(component.get('hasNext'), 'has next');
+  ok(!component.get('hasPrev'), '! has prev');
+
+  Ember.run(component, 'set', 'currentPage', 2);
+
+  ok(component.get('hasNext'), 'has next');
+  ok(component.get('hasPrev'), 'has prev');
+
+  Ember.run(component, 'set', 'currentPage', 3);
+
+  ok(!component.get('hasNext'), '! has next');
+  ok(component.get('hasPrev'), 'has prev');
+});

--- a/tests/unit/models/operation-test.js
+++ b/tests/unit/models/operation-test.js
@@ -13,6 +13,8 @@ moduleForModel('operation', 'Operation', {
     'model:database',
     'model:permission',
     'model:role',
+    'model:service',
+    'model:vhost',
 
     'adapter:operation',
     'serializer:application'
@@ -53,6 +55,100 @@ test('when creating an operation for a db, POSTs to /databases/:id/operations', 
   return Ember.run(function(){
     return op.save().then(function(_op){
       ok(true, 'operation saved');
+    });
+  });
+});
+
+test('store.find("operation", {app:app, page:page}) formats the URL correctly"', function(){
+  expect(4);
+
+  var store = this.store();
+  var app;
+  var firstRequest = true;
+
+  stubRequest('get', '/apps/app-id/operations', function(request){
+    if (firstRequest) {
+      firstRequest = false;
+      equal(request.queryParams.page, "1", "first request has page=1 query param");
+
+      return this.success({
+        page: 1,
+        total_pages: 2,
+        _embedded: {
+          operations: [{id:'op-1'}]
+        }
+      });
+    } else {
+      equal(request.queryParams.page, "2", "second request has page=2 query param");
+
+      return this.success({
+        page: 2,
+        total_pages: 2,
+        _embedded: {
+          operations: [{id:'op-2'}]
+        }
+      });
+    }
+  });
+
+  return Ember.run(function(){
+    app = store.push('app', {id: 'app-id'});
+
+    return store.find('operation', {app:app, page:1}).then(function(){
+      deepEqual(store.metadataFor('operation'),
+                {page:1,total_pages:2}, 'store has correct metadata first time');
+
+      return store.find('operation', {app:app, page:2});
+    }).then(function(){
+      deepEqual(store.metadataFor('operation'),
+                {page:2,total_pages:2}, 'store has correct metadata second time');
+    });
+  });
+});
+
+test('store.find("operation", {database:database, page:page}) formats the URL correctly"', function(){
+  expect(4);
+
+  var store = this.store();
+  var db;
+  var firstRequest = true;
+
+  stubRequest('get', '/databases/db-id/operations', function(request){
+    if (firstRequest) {
+      firstRequest = false;
+      equal(request.queryParams.page, "1", "first request has page=1 query param");
+
+      return this.success({
+        page: 1,
+        total_pages: 2,
+        _embedded: {
+          operations: [{id:'op-1'}]
+        }
+      });
+    } else {
+      equal(request.queryParams.page, "2", "second request has page=2 query param");
+
+      return this.success({
+        page: 2,
+        total_pages: 2,
+        _embedded: {
+          operations: [{id:'op-2'}]
+        }
+      });
+    }
+  });
+
+  return Ember.run(function(){
+    db = store.push('database', {id: 'db-id'});
+
+    return store.find('operation', {database:db, page:1}).then(function(){
+      deepEqual(store.metadataFor('operation'),
+                {page:1,total_pages:2}, 'store has correct metadata first time');
+
+      return store.find('operation', {database:db, page:2});
+    }).then(function(){
+      deepEqual(store.metadataFor('operation'),
+                {page:2,total_pages:2}, 'store has correct metadata second time');
     });
   });
 });


### PR DESCRIPTION
@mixonic for your review

  * Override findQuery for operation adapter to allow pagination
  * add pagination in {{aptible-pagination}} component
  * Paginated route and controller mixins for shared behaviors
  * update 'page' query param in url
  * dry tests with shared test helper functions

fixes #49 refs #51

cc @fancyremarker

This uses the current_page, total_count and per_page meta data
provided by the API as of https://github.com/aptible/api.aptible.com/pull/146