### PR TITLE
Add settings profile, admin and ssh key pages

### DIFF
--- a/app/adapters/ssh-key.js
+++ b/app/adapters/ssh-key.js
@@ -1,0 +1,31 @@
+import AuthAdapter from './auth';
+import buildURLWithPrefixMap from '../utils/build-url-with-prefix-map';
+import Ember from 'ember';
+
+export default AuthAdapter.extend({
+  buildURL: buildURLWithPrefixMap({
+    'users': 'user.id'
+  }),
+
+  // To delete an ssh-key, the adapter should send a DELETE to /ssh_keys/:id,
+  // but it POSTs to /users/:user_id/ssh_keys.
+  // Override deleteRecord to remove the "/users/:user_id" from the
+  // url for a DELETE.
+  deleteRecord: function(store, type, record){
+    var id = Ember.get(record, 'id');
+    var userId = Ember.get(record, 'user.id');
+
+    var url = this.buildURL(type.typeKey, id, record);
+
+    if (userId) {
+      url = url.replace("/users/" + userId, "");
+    }
+
+    return this.ajax(url, "DELETE");
+  },
+
+  // In URLs and JSON payloads, use "ssh_keys" instead of "sshKeys"
+  pathForType: function(type){
+    return Ember.String.pluralize( Ember.String.decamelize(type) );
+  }
+});

--- a/app/models/ssh-key.js
+++ b/app/models/ssh-key.js
@@ -1,0 +1,9 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  name: DS.attr('string'),
+  sshPublicKey: DS.attr('string'),
+  publicKeyFingerprint: DS.attr('string'),
+
+  user: DS.belongsTo('user', {async:true})
+});

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -7,10 +7,18 @@ export default DS.Model.extend({
   username: DS.attr('string'),
   password: DS.attr('string'),
 
+  // used when changing a user's password. Set as an `attr` so that it
+  // will be sent to the API
+  currentPassword: DS.attr('string'),
+
+  // not persisted, used when changing a user's password
+  passwordConfirmation: null,
+
   // relationships
   token: DS.belongsTo('token', {async: true}),
   roles: DS.hasMany('role', {async:true}),
-  organizations: DS.hasMany('organizations', {async:true}),
+  organizations: DS.hasMany('organization', {async:true}),
+  sshKeys: DS.hasMany('ssh-key', {async:true}),
 
   // check ability, returns a promise
   // e.g.: user.can('manage', stack).then(function(boolean){ ... });

--- a/app/router.js
+++ b/app/router.js
@@ -58,6 +58,12 @@ Router.map(function() {
   this.route("logout");
   this.route("signup");
 
+  this.route('settings', {}, function(){
+    this.route('admin');
+    this.route('profile');
+    this.route('ssh');
+  });
+
   this.route("verify", {
     path: "verify/:verification_code"
   });

--- a/app/settings/admin/controller.js
+++ b/app/settings/admin/controller.js
@@ -1,0 +1,10 @@
+import Ember from 'ember';
+
+var and = Ember.computed.and;
+
+export default Ember.Controller.extend({
+  isSavingPassword: and('changingPassword',
+                        'session.currentUser.isSaving'),
+  isSavingEmail: and('changingEmail',
+                     'session.currentUser.isSaving')
+});

--- a/app/settings/admin/route.js
+++ b/app/settings/admin/route.js
@@ -1,0 +1,64 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  model: function(){
+    return this.session.get('currentUser');
+  },
+
+  actions: {
+    changePassword: function(){
+      var controller = this.controller;
+
+      // Changing password is a 2-step process. We show the
+      // "enter current password" input after clicking the button once
+      if (!controller.get('changingPassword')) {
+        controller.set('changingPassword', true);
+        return;
+      }
+
+      controller.set('passwordError', null);
+
+      var user = this.currentModel;
+
+      user.save().then(function(){
+        controller.set('changingPassword', false);
+        user.set('passwordConfirmation', null);
+        user.set('currentPassword', null);
+
+        // TODO this will leave the user in a dirty state.
+        user.set('password', null);
+      }).catch(function(e){
+        var message = e.responseJSON ? e.responseJSON.message : e.message;
+        if (!message) { message = 'Unknown error'; }
+        controller.set('passwordError',message);
+      });
+    },
+
+    changeEmail: function(){
+      var controller = this.controller;
+
+      // Changing email is a 2-step process. We show the
+      // "enter current password" input after clicking the button once
+      if (!controller.get('changingEmail')) {
+        controller.set('changingEmail', true);
+        return;
+      }
+
+      controller.set('emailError', null);
+
+      var user = this.currentModel;
+
+      user.save().catch(function(e){
+        var message = e.responseJSON ? e.responseJSON.message : e.message;
+        if (!message) { message = 'Unknown error'; }
+        controller.set('emailError',message);
+      }).finally(function(){
+
+        // Clears the current password input
+        user.set('currentPassword', null);
+
+        controller.set('changingEmail', false);
+      });
+    }
+  }
+});

--- a/app/settings/admin/template.hbs
+++ b/app/settings/admin/template.hbs
@@ -1,0 +1,84 @@
+<div class="panel-group">
+  <div class="panel panel-default">
+    <div class="panel-heading"><h3>Change Your Password</h3></div>
+    <div class="panel-body">
+      {{#if passwordError}}
+        <div class="alert alert-warning">
+          {{passwordError}}
+        </div>
+      {{/if}}
+      <form action="">
+        <div class="form-group">
+          <label for="password">New password</label>
+          {{input type="password"
+                  class="form-control" placholder="New password"
+                  value=model.password name="password"}}
+        </div>
+        <div class="form-group">
+          <label for="confirm-password">Confirm new password</label>
+          {{input type="password"
+                  class="form-control" placholder="New password"
+                  value=model.passwordConfirmation
+                  name="confirm-password"}}
+        </div>
+        {{#if changingPassword}}
+          <div class="form-group">
+            <label for="current-password">Current password</label>
+            {{input type="password"
+                    class="form-control" placholder="Current password"
+                    value=model.currentPassword
+                    name="current-password"}}
+          </div>
+        {{/if}}
+        <div class="form-group">
+          <button {{action 'changePassword'}}
+            {{bind-attr disabled=model.isSaving}}
+            class="btn btn-primary" type="submit">
+
+            {{#if isSavingPassword}}
+              Saving
+            {{else}}
+              Change password
+            {{/if}}
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+  <div class="panel panel-default">
+    <div class="panel-heading"><h3>Change Your Email</h3></div>
+    <div class="panel-body">
+      {{#if emailError}}
+        <div class="alert alert-warning">
+          {{emailError}}
+        </div>
+      {{/if}}
+      <form>
+        <div class="form-group">
+          <label for="email">Email</label>
+          {{input type="email"
+                  class="form-control" placeholder="Email"
+                  value=model.email name="email"}}
+        </div>
+        {{#if changingEmail}}
+          <div class="form-group">
+            <label for="password">Please enter your current password</label>
+            {{input type="password"
+                    class="form-control" placeholder="Current password"
+                    value=model.currentPassword
+                    name="current-password"}}
+          </div>
+        {{/if}}
+        <div class="form-group">
+          <button {{action 'changeEmail'}} class="btn btn-primary" type="submit">
+            {{#if isSavingEmail}}
+              Saving
+            {{else}}
+              Change email
+            {{/if}}
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>

--- a/app/settings/index/route.js
+++ b/app/settings/index/route.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  redirect: function(){
+    this.replaceWith('settings.profile');
+  }
+});

--- a/app/settings/profile/route.js
+++ b/app/settings/profile/route.js
@@ -1,0 +1,20 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  model: function(){
+    return this.session.get('currentUser');
+  },
+
+  setupController: function(controller, model){
+    controller.set('model', model);
+    controller.set('userName', model.get('name'));
+  },
+
+  actions: {
+    submit: function(newName){
+      var user = this.currentModel;
+      user.set('name', newName);
+      user.save();
+    }
+  }
+});

--- a/app/settings/profile/template.hbs
+++ b/app/settings/profile/template.hbs
@@ -1,0 +1,45 @@
+<div class="panel-group">
+  <div class="panel panel-default">
+    <div class="panel-heading"><h3>Your Profile</h3></div>
+    <div class="panel-body">
+      <form action="">
+        <div class="form-group clearfix update-gravatar">
+          <label class="block">Profile Picture</label>
+          <div class="gravatar lg">
+            {{gravatar-image email=model.email}}
+          </div>
+
+          <div class="input-group update-gravatar-info">
+            <h5>
+              Use <a href="https://en.gravatar.com/">Gravatar</a> to update your profile picture.
+            </h5>
+            <h6>
+              Your gravatar email is <strong class='email'>{{model.email}}</strong>
+            </h6>
+            <div>
+              <a class="btn btn-xs btn-default" href="https://en.gravatar.com/" target="_blank">Change</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="form-group">
+          <label for="name">Name</label>
+
+          {{input value=userName name="name" class="form-control"}}
+        </div>
+
+        <div class="form-group">
+          <button {{action "submit" userName}}
+             {{bind-attr disabled=model.isSaving}}
+             class="btn btn-primary" type="submit">
+            {{#if model.isSaving}}
+              Saving
+            {{else}}
+              Update profile
+            {{/if}}
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>

--- a/app/settings/ssh/controller.js
+++ b/app/settings/ssh/controller.js
@@ -1,0 +1,13 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  error: null,
+  newKey: null,
+
+  // do not show the key that the user is in the progress of creating
+  validKeys: function(){
+    return this.get('model').filter(function(key){
+      return key.get('isLoaded') && !key.get('isDirty');
+    });
+  }.property('model.@each.isLoaded', 'model.@each.isDirty')
+});

--- a/app/settings/ssh/route.js
+++ b/app/settings/ssh/route.js
@@ -1,0 +1,53 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  model: function(){
+    var user = this.session.get('currentUser');
+
+    return user.get('sshKeys');
+  },
+
+  setupController: function(controller, model){
+    controller.set('model', model);
+  },
+
+  actions: {
+    addKey: function(){
+      this.controller.set('newKey', this.store.createRecord('ssh-key', {
+        user: this.session.get('currentUser')
+      }));
+    },
+
+    cancelSaveKey: function(){
+      this.controller.get('newKey').deleteRecord();
+      this.controller.set('newKey', null);
+      this.controller.set('error', null);
+    },
+
+    saveKey: function(){
+      var controller = this.controller;
+
+      if (controller.get('newKey.isSaving')) { return; }
+
+      var key = this.controller.get('newKey');
+
+      key.save().then(function(){
+        controller.set('error', null); // clear error
+        controller.set('newKey', null); // clear key
+      }).catch(function(e){
+        controller.set('error', e.message);
+      });
+    },
+
+    deleteKey: function(key){
+      var controller = this.controller;
+
+      key.destroyRecord().then(function(){
+        controller.set('error', null);
+      }).catch(function(){
+        controller.set('error', 'There was an error deleting this key.');
+        key.rollback();
+      });
+    }
+  }
+});

--- a/app/settings/ssh/template.hbs
+++ b/app/settings/ssh/template.hbs
@@ -1,0 +1,64 @@
+<div class="panel panel-default">
+  <div class="panel-heading">
+    <h3>SSH Keys</h3>
+  </div>
+  <div class="ssh-keys">
+    {{#each validKeys as |sshKey|}}
+    <div class="ssh-key-item">
+      <div class="ssh-key-info">
+        <label>{{sshKey.name}}</label>
+        <div class="ssh-key-fingerprint">{{sshKey.publicKeyFingerprint}}</div>
+      </div>
+      <div class="ssh-key-nav app-list-nav">
+        <ul class="nav nav-pills sub-nav-tabs">
+          <li>
+            <a class="delete-key" {{action 'deleteKey' sshKey}}>
+              <i class="fa fa-times"></i>
+              <span class="button-label">Delete SSH Key</span>
+            </a>
+          </li>
+        </ul>
+      </div>
+    </div>
+    {{/each}}
+  </div>
+  <div class="panel-body">
+    {{#if error}}
+      <div class="alert alert-warning">
+        {{error}}
+      </div>
+    {{/if}}
+
+    {{#if newKey}}
+      <h4>Add SSH Key</h4>
+      <form>
+        <div class="form-group">
+          <label class="block" for="name">SSH Key Name</label>
+          {{input value=newKey.name name="name" class="form-control"}}
+        </div>
+        <div class="form-group">
+          <label>Set your public SSH key</label>
+          {{textarea value=newKey.sshPublicKey name="ssh-public-key" class="form-control monospace" cols="40" rows="10"}}
+        </div>
+
+        <button {{action 'cancelSaveKey'}} {{bind-attr disabled=newKey.isSaving}}
+                class="nevermind btn btn-lg-text btn-default pull-left"
+                type="button">
+          Nevermind
+        </button>
+
+        <button {{action 'saveKey'}} {{bind-attr disabled=newKey.isSaving}}
+                class="btn btn-lg-text btn-primary confirm-action"
+                type="submit">
+          {{#if newKey.isSaving}}Saving{{else}}Save new SSH key{{/if}}
+        </button>
+      </form>
+    {{else}}
+      {{#if model.length}}
+      <button class='btn btn-primary' {{action 'addKey'}}>Add another SSH key</button>
+      {{else}}
+      <button class='btn btn-primary' {{action 'addKey'}}>Add your first SSH key</button>
+      {{/if}}
+    {{/if}}
+  </div>
+</div>

--- a/app/settings/template.hbs
+++ b/app/settings/template.hbs
@@ -1,0 +1,24 @@
+<div class="container">
+  <div class="row">
+    <div class="col-xs-4">
+      <ul class="nav sidebar-nav">
+        <li class='title'>Profile Settings</li>
+
+        {{#link-to 'settings.profile' tagName='li'}}
+          {{link-to 'Profile' 'settings.profile'}}
+        {{/link-to}}
+
+        {{#link-to 'settings.admin' tagName='li'}}
+          {{link-to 'Account Settings' 'settings.admin'}}
+        {{/link-to}}
+
+        {{#link-to 'settings.ssh' tagName='li'}}
+          {{link-to 'SSH Keys' 'settings.ssh'}}
+        {{/link-to}}
+      </ul>
+    </div>
+    <div class="col-xs-8">
+      {{outlet}}
+    </div>
+  </div>
+</div>

--- a/app/settings/view.js
+++ b/app/settings/view.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+export default Ember.View.extend({
+  layoutName: 'layouts/dashboard'
+});

--- a/app/templates/-current-user-header.hbs
+++ b/app/templates/-current-user-header.hbs
@@ -22,7 +22,7 @@
             {{/dashboard-dropdown-item}}
 
             {{#dashboard-dropdown-item}}
-              {{#link-to-aptible app="legacy-dashboard" path="settings"}}Settings{{/link-to-aptible}}
+              {{#link-to "settings"}}Settings{{/link-to}}
             {{/dashboard-dropdown-item}}
 
             {{dashboard-dropdown-divider}}

--- a/tests/acceptance/settings/settings-account-test.js
+++ b/tests/acceptance/settings/settings-account-test.js
@@ -1,0 +1,242 @@
+import Ember from 'ember';
+import startApp from '../../helpers/start-app';
+import { stubRequest } from '../../helpers/fake-server';
+
+var App;
+
+var settingsUrl = '/settings';
+var settingsAccountUrl = settingsUrl + '/admin';
+var userId = 'user1'; // from signInAndVisit helper
+var userEmail = 'stubbed-user@gmail.com'; // from signInAndVisit helper
+var userName = 'stubbed user'; // from signInAndVisit helper
+
+var userApiUrl = '/users/' + userId;
+
+module('Acceptance: User Settings: Account', {
+  setup: function() {
+    App = startApp();
+    stubStacks();
+  },
+  teardown: function() {
+    Ember.run(App, 'destroy');
+  }
+});
+
+// Helper methods
+
+function emailInput(){
+  return find('input[name="email"]');
+}
+
+function changeEmailButton(){
+  return find('button:contains(Change email)');
+}
+
+function passwordInput(){
+  return find('input[name="password"]');
+}
+
+function confirmPasswordInput(){
+  return find('input[name="confirm-password"]');
+}
+
+function currentPasswordInput(){
+  return find('input[name="current-password"]');
+}
+
+function changePasswordButton(){
+  return find('button:contains(Change password)');
+}
+
+test(settingsAccountUrl + ' requires authentication', function(){
+  expectRequiresAuthentication(settingsAccountUrl);
+});
+
+test('visit ' + settingsAccountUrl + ' shows change password form', function(){
+  signInAndVisit(settingsAccountUrl);
+
+  andThen(function(){
+    // change password
+
+    ok(find('h3:contains(Change Your Password)').length,
+       'has change password header' );
+
+    ok(passwordInput().length, 'has password input');
+    ok(confirmPasswordInput().length, 'has confirm password input');
+    ok(changePasswordButton().length, 'has change password button');
+    ok(!currentPasswordInput().length, 'shows no current password input');
+    click(changePasswordButton());
+  });
+
+  andThen(function(){
+    ok( currentPasswordInput().length, 'shows current password input');
+  });
+});
+
+test('visit ' + settingsAccountUrl + ' allows changing password', function(){
+  expect(5);
+
+  signInAndVisit(settingsAccountUrl);
+
+  var newPassword = 'abcdefghi',
+      oldPassword = 'defghiljk';
+
+  stubRequest('put', 'users/user1', function(request){
+    var user = JSON.parse(request.requestBody);
+
+    equal(user.current_password, oldPassword);
+    equal(user.password, newPassword);
+
+    return this.success({
+      id: 'user1'
+    });
+  });
+
+  andThen(function(){
+    fillIn(passwordInput(), newPassword );
+    fillIn(confirmPasswordInput(), newPassword );
+    click(changePasswordButton());
+  });
+
+  andThen(function(){
+    fillIn(currentPasswordInput(), oldPassword);
+    click(changePasswordButton());
+  });
+
+  andThen(function(){
+    ok(Ember.isBlank(passwordInput().val()), 'password input is empty');
+    ok(Ember.isBlank(confirmPasswordInput().val()),
+       'password confirm input is empty');
+    ok(!currentPasswordInput().length, 'current password input is not shown');
+  });
+});
+
+test('visit ' + settingsAccountUrl + ' and change password with errors', function(){
+  expect(2);
+
+  signInAndVisit(settingsAccountUrl);
+
+  var newPassword = 'abcdefghi',
+      oldPassword = 'defghiljk';
+
+  stubRequest('put', 'users/user1', function(request){
+    var user = JSON.parse(request.requestBody);
+
+    return this.error({
+      code: 401,
+      error: 'invalid_credentials',
+      message: 'Invalid password'
+    });
+  });
+
+  andThen(function(){
+    fillIn(passwordInput(), newPassword );
+    fillIn(confirmPasswordInput(), newPassword );
+    click(changePasswordButton());
+  });
+
+  andThen(function(){
+    fillIn(currentPasswordInput(), oldPassword);
+    click(changePasswordButton());
+  });
+
+  andThen(function(){
+    var error = find('.alert');
+    ok(error.length, 'shows error');
+    ok(error.text().indexOf('Invalid password') > -1,
+       'shows error message');
+  });
+});
+test('visit ' + settingsAccountUrl + ' shows change email form', function(){
+  signInAndVisit(settingsAccountUrl);
+
+  andThen(function(){
+    // change email
+
+    ok( find('h3:contains(Change Your Email)').length,
+        'has change email header' );
+
+    ok( emailInput().length,
+        'has email input');
+
+    equal( emailInput().val(), userEmail,
+           'email input has user email value');
+
+    ok(!currentPasswordInput().length,
+       'does not show current password input');
+
+    ok( changeEmailButton().length, 'has change email button');
+    click(changeEmailButton());
+  });
+
+  andThen(function(){
+    ok(currentPasswordInput().length, 'shows current password input');
+    ok(changeEmailButton().length, 'still shows change email button');
+  });
+});
+
+test('visit ' + settingsAccountUrl + ' allows change email', function(){
+  expect(2);
+
+  signInAndVisit(settingsAccountUrl);
+
+  var newEmail = 'newEmail@example.com';
+  var currentPassword = 'alkjsdf';
+
+  stubRequest('put', '/users/user1', function(request){
+    var user = JSON.parse(request.requestBody);
+
+    equal(user.email, newEmail);
+    equal(user.current_password, currentPassword);
+
+    return this.success({
+      id: 'user1',
+      email: newEmail
+    });
+  });
+
+  andThen(function(){
+    fillIn(emailInput(), newEmail);
+    click(changeEmailButton());
+  });
+
+  andThen(function(){
+    fillIn(currentPasswordInput(), currentPassword);
+    click(changeEmailButton());
+  });
+});
+
+test('visit ' + settingsAccountUrl + ' change email and errors', function(){
+  expect(2);
+
+  signInAndVisit(settingsAccountUrl);
+
+  var newEmail = 'newEmail@example.com';
+  var currentPassword = 'alkjsdf';
+
+  stubRequest('put', '/users/user1', function(request){
+    var user = JSON.parse(request.requestBody);
+
+    return this.error({
+      code: 401,
+      error: 'invalid_credentials',
+      message: 'Invalid password'
+    });
+  });
+
+  andThen(function(){
+    fillIn(emailInput(), newEmail);
+    click(changeEmailButton());
+  });
+
+  andThen(function(){
+    fillIn(currentPasswordInput(), currentPassword);
+    click(changeEmailButton());
+  });
+
+  andThen(function(){
+    var error = find('.alert');
+    ok(error.length, 'shows error div');
+    ok(error.text().indexOf('Invalid password'), 'shows error message');
+  });
+});

--- a/tests/acceptance/settings/settings-profile-test.js
+++ b/tests/acceptance/settings/settings-profile-test.js
@@ -1,0 +1,119 @@
+import Ember from 'ember';
+import startApp from '../../helpers/start-app';
+import { stubRequest } from '../../helpers/fake-server';
+
+var App;
+
+var settingsUrl = '/settings';
+var settingsProfileUrl = settingsUrl + '/profile';
+var userId = 'user1'; // from signInAndVisit helper
+var userEmail = 'stubbed-user@gmail.com'; // from signInAndVisit helper
+var userName = 'stubbed user'; // from signInAndVisit helper
+
+var userApiUrl = '/users/' + userId;
+
+module('Acceptance: User Settings: Profile', {
+  setup: function() {
+    App = startApp();
+    stubStacks();
+  },
+  teardown: function() {
+    Ember.run(App, 'destroy');
+  }
+});
+
+test(settingsUrl + ' requires authentication', function(){
+  expectRequiresAuthentication(settingsUrl);
+});
+
+test(settingsProfileUrl + ' requires authentication', function(){
+  expectRequiresAuthentication(settingsProfileUrl);
+});
+
+test('visit ' + settingsUrl + ' redirects to profile', function(){
+  signInAndVisit(settingsUrl);
+  andThen(function(){
+    equal(currentPath(), 'settings.profile');
+  });
+});
+
+function dropdownContaining(name){
+  return find('.dropdown.current-user:contains(' + name + ')');
+}
+
+function nameInput(){
+  return find('input[name="name"]');
+}
+
+function updateProfileButton(){
+  return find('button:contains(Update profile)');
+}
+
+test('visit ' + settingsProfileUrl + ' shows profile info', function(){
+  signInAndVisit(settingsProfileUrl);
+
+  andThen(function(){
+    ok( find('h3:contains(Your Profile)').length,
+        'has header' );
+
+    ok( find('label:contains(Profile Picture)').length,
+        'has profile picture block' );
+
+    ok( find('.gravatar img').length,
+        'has gravatar img');
+
+    ok( find('.email:contains(' + userEmail + ')').length,
+        'has user email');
+
+    ok( nameInput().length, 'input for name');
+
+    equal( nameInput().val(), userName,
+           'input for name is prefilled with user name');
+
+    ok( updateProfileButton().length,
+        'button to update profile' );
+  });
+});
+
+test('visit ' + settingsProfileUrl + ' allows updating name', function(){
+  expect(6);
+
+  var newName = 'Graham Shuttlesworth';
+
+  stubRequest('put', userApiUrl, function(request){
+    ok(true, 'calls PUT ' + userApiUrl);
+    var user = JSON.parse(request.requestBody);
+
+    equal(user.name, newName, 'updates with new name: ' + newName);
+
+    return this.success({
+      id: userId,
+      name: user.name,
+      email: user.email
+    });
+  });
+
+  signInAndVisit(settingsProfileUrl);
+
+  andThen(function(){
+    ok( dropdownContaining(userName).length,
+        'user dropdown shows current user name: ' + userName);
+
+    fillIn(nameInput(), newName);
+  });
+
+  andThen(function(){
+    ok( dropdownContaining(userName).length,
+        'user dropdown still shows current user name: ' + userName);
+
+    click( updateProfileButton() );
+  });
+
+  andThen(function(){
+    ok( !dropdownContaining(userName).length,
+        'user dropdown no longer shows old name: ' + userName);
+
+    ok( dropdownContaining(newName).length,
+        'user dropdown now shows new name: ' + newName);
+  });
+});

--- a/tests/acceptance/settings/settings-ssh-test.js
+++ b/tests/acceptance/settings/settings-ssh-test.js
@@ -1,0 +1,213 @@
+import Ember from 'ember';
+import startApp from '../../helpers/start-app';
+import { stubRequest } from '../../helpers/fake-server';
+
+var App;
+
+var settingsUrl = '/settings';
+var settingsSshUrl = settingsUrl + '/ssh';
+var userId = 'user1'; // from signInAndVisit helper
+var userEmail = 'stubbed-user@gmail.com'; // from signInAndVisit helper
+var userName = 'stubbed user'; // from signInAndVisit helper
+
+var userApiUrl = '/users/' + userId;
+
+module('Acceptance: User Settings: Ssh', {
+  setup: function() {
+    App = startApp();
+    stubStacks();
+  },
+  teardown: function() {
+    Ember.run(App, 'destroy');
+  }
+});
+
+function stubGetKeys(keys){
+  stubRequest('get', '/users/user1/ssh_keys', function(){
+    return this.success({
+      _embedded: {
+        ssh_keys: keys
+      }
+    });
+  });
+}
+
+function addButton(){
+  return find('button:contains(Add another SSH key)');
+}
+
+function addFirstButton(){
+  return findWithAssert('button:contains(Add your first SSH key)');
+}
+
+function deleteButton(){
+  return findWithAssert('a.delete-key');
+}
+
+function saveKeyButton(){
+  return find('button:contains(Save new SSH key)');
+}
+
+function nevermindButton(){
+  return findWithAssert('button:contains(Nevermind)');
+}
+
+function nameInput(){
+  return findWithAssert('input[name="name"]');
+}
+
+function publicKeyInput(){
+  return findWithAssert('textarea[name="ssh-public-key"]');
+}
+
+test(settingsSshUrl + ' requires authentication', function(){
+  expectRequiresAuthentication(settingsSshUrl);
+});
+
+test('visit ' + settingsSshUrl + ' shows ssh keys', function(){
+  var keys = [
+    {id: 1, name: 'key1', public_key_fingerprint: '3b:55:f2:c6:4f'},
+    {id: 2, name: 'key2', public_key_fingerprint: '4b:56:f3:c7:5f'}
+  ];
+
+  stubGetKeys(keys);
+  signInAndVisit(settingsSshUrl);
+
+  andThen(function(){
+    ok( find('h3:contains(SSH Keys)').length,
+        'has header' );
+
+    equal( find('.ssh-key-item').length, keys.length,
+           'has ' + keys.length + ' ssh keys');
+
+    ok( addButton().length, 'has add button');
+    equal(deleteButton().length, keys.length,
+          'has ' + keys.length + ' delete buttons');
+
+    click(addButton());
+  });
+
+  andThen(function(){
+    ok(nameInput().length, 'has name input');
+    ok(publicKeyInput().length, 'has ssh-public-key input');
+    ok( saveKeyButton().length, 'has save key button' );
+    ok( nevermindButton().length, 'has cancel button' );
+    ok(!addButton().length, 'does not show add button when adding a key');
+  });
+});
+
+test('visit ' + settingsSshUrl + ' with no key shows button to add key', function(){
+  stubGetKeys([]);
+  signInAndVisit(settingsSshUrl);
+
+  andThen(function(){
+    ok( addFirstButton().length, 'has Add First button');
+  });
+});
+
+test('visit ' + settingsSshUrl + ' allows adding a key', function(){
+  expect(4);
+
+  stubGetKeys([]);
+
+  var keyName   = "my-test-key";
+  var publicKey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC90B4...";
+
+  stubRequest('post', '/users/user1/ssh_keys', function(request){
+    var json = JSON.parse(request.requestBody);
+
+    equal(json.name, keyName);
+    equal(json.ssh_public_key, publicKey);
+
+    return this.success({
+      id: 'ssh-key-id',
+      name: json.name,
+      ssh_public_key: json.ssh_public_key,
+      public_key_fingerprint: "07:04:3a:1d:0c:9c:60:1a:09:70:4b:ca:f9:89:a3:e5"
+    });
+  });
+
+  signInAndVisit(settingsSshUrl);
+
+  andThen(function(){
+    click( addFirstButton() );
+  });
+
+  andThen(function(){
+    click( nevermindButton() );
+  });
+
+  andThen(function(){
+    ok( !saveKeyButton().length, 'save button is not shown after cancel' );
+    click( addFirstButton() );
+  });
+
+  andThen(function(){
+    fillIn( nameInput(), keyName );
+    fillIn( publicKeyInput(), publicKey);
+    click( saveKeyButton() );
+  });
+
+  andThen(function(){
+    ok( find('.ssh-key-item:contains(' + keyName + ')').length,
+        'shows key with name: ' + keyName);
+  });
+});
+
+test('visit ' + settingsSshUrl + ' and adding a key when it returns an error', function(){
+  stubGetKeys([]);
+
+  var keyName = "my-test-key";
+  var publicKey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC90B4...";
+
+  stubRequest('post', '/users/user1/ssh_keys', function(request){
+    return this.error({
+      message: 'The key is invalid'
+    });
+  });
+
+  signInAndVisit(settingsSshUrl);
+
+  andThen(function(){
+    click( addFirstButton() );
+    fillIn( nameInput(), keyName );
+    fillIn( publicKeyInput(), publicKey );
+
+    click('button:contains(Save new SSH key)');
+  });
+
+  andThen(function(){
+    var error = find('.alert');
+    ok( error.length, 'error div is shown');
+
+    ok( error.text().indexOf('The key is invalid') > -1,
+        'displays error text' );
+  });
+});
+
+test('visit ' + settingsSshUrl + ' and delete a key', function(){
+  expect(2);
+
+  var keys = [
+    {id: 1, name: 'key1', public_key_fingerprint: '3b:55:f2:c6:4f'}
+  ];
+  var deleteUrl = '/ssh_keys/1';
+
+  stubGetKeys(keys);
+
+  stubRequest('delete', deleteUrl, function(){
+    ok(true, 'calls DELETE ' + deleteUrl);
+    return this.success({id:1});
+  });
+
+  signInAndVisit(settingsSshUrl);
+
+  andThen(function(){
+    click( deleteButton() );
+  });
+
+  andThen(function(){
+    equal( find('.ssh-key-item').length, 0,
+           'after deleting, 0 keys are shown');
+  });
+});

--- a/tests/helpers/aptible-helpers.js
+++ b/tests/helpers/aptible-helpers.js
@@ -10,7 +10,9 @@ Ember.Test.registerAsyncHelper('signIn', function(app){
     var store = app.__container__.lookup('store:main');
     var user = store.push('user', {
       id: 'user1',
-      name: 'stubbed user'
+      name: 'stubbed user',
+      email: 'stubbed-user@gmail.com',
+      links: { sshKeys: '/users/user1/ssh_keys' }
     });
     sm.transitionTo('authenticated');
     session.set('content.currentUser', user);

--- a/tests/unit/models/ssh-key-test.js
+++ b/tests/unit/models/ssh-key-test.js
@@ -1,0 +1,34 @@
+import {
+  moduleForModel,
+  test
+} from 'ember-qunit';
+import { stubRequest } from "../../helpers/fake-server";
+import Ember from 'ember';
+
+moduleForModel('ssh-key', 'SshKey', {
+  // Specify the other units that are required for this test.
+  needs: [
+    'model:role',
+    'model:organization',
+    'model:user',
+    'model:token',
+
+    'adapter:application',
+    'adapter:ssh-key',
+    'adapter:user',
+    'serializer:application',
+  ]
+});
+
+/*
+ * There is a bug in the interaction between ember data and the
+ * isolated container used in `moduleForModel` unit tests
+ * that causes issues unit-testing this ssh-key model.
+ * The store will end up incorrectly unable to find the model
+ * when it calls `modelFor('sshKey')`.
+ * More details are here: https://github.com/bantic/data/pull/1
+ *
+ * There should be tests here that POSTing and DELETEing ssh keys
+ * use the correct urls (/users/:user_id/ssh_keys and /ssh_keys/:ssh_key_id
+ * for the latter, respectively).
+ */

--- a/tests/unit/models/user-test.js
+++ b/tests/unit/models/user-test.js
@@ -5,7 +5,7 @@ import {
 
 moduleForModel('user', 'User', {
   // Specify the other units that are required for this test.
-  needs: ['model:token', 'model:role', 'model:organization']
+  needs: ['model:token', 'model:role', 'model:organization','model:ssh-key']
 });
 
 test('it exists', function() {

--- a/tests/unit/torii-adapters/aptible-test.js
+++ b/tests/unit/torii-adapters/aptible-test.js
@@ -17,6 +17,7 @@ moduleFor('torii-adapter:aptible', 'Torii Adapter: Aptible', {
     'model:user',
     'model:role',
     'model:organization',
+    'model:ssh-key',
     'adapter:application',
     'serializer:application'
   ],

--- a/tests/unit/utils/can-test.js
+++ b/tests/unit/utils/can-test.js
@@ -22,6 +22,7 @@ moduleForModel('user', 'Utils - #can', {
     'model:permission',
     'model:organization',
     'model:vhost',
+    'model:ssh-key',
 
     'adapter:application',
     'serializer:application'


### PR DESCRIPTION
The ajax is not yet wired up for editing name, password,
email or adding ssh keys.

refs #51 #66

The pages are now working for displaying data. The link to settings is obscured by the navbar (#67) but you can go directly to `/settings` to see the pages.

Notes for wiring up the data are in a separate issue.

This PR makes the pages look like:

![fdiu2tp6fj](https://cloud.githubusercontent.com/assets/2023/5786382/1b20c46a-9db2-11e4-9a4f-cb6e1381e789.gif)

@sandersonet for you cc @mixonic 