### PR TITLE
Deprovision pane for apps

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -35,6 +35,16 @@ export default HalAdapter.extend({
     } else {
       return error;
     }
+  },
+
+  deleteRecord: function(store, type, record){
+    var id = Ember.get(record, 'id');
+    var url = this.buildURL(type.typeKey, id);
+    return this.ajax(url, "DELETE");
+  },
+
+  find: function(store, type, id /*, record */) {
+    return this.ajax(this.buildURL(type.typeKey, id), 'GET');
   }
 
 });

--- a/app/app/deprovision/route.js
+++ b/app/app/deprovision/route.js
@@ -1,0 +1,29 @@
+import Ember from "ember";
+
+export default Ember.Route.extend({
+
+  actions: {
+    deprovision: function(){
+      var app = this.currentModel;
+      var route = this;
+      var controller = this.controller;
+      var store = this.store;
+      controller.set('error', null);
+
+      app.get('stack').then(function(stack) {
+        var op = store.createRecord('operation', {
+          type: 'deprovision',
+          app: app
+        });
+        return op.save().then(function(){
+          return app.reload();
+        }).then(function(){
+          route.transitionTo('stack', stack);
+        }, function(e){
+          controller.set('error', e);
+        });
+      });
+    }
+  }
+
+});

--- a/app/app/deprovision/template.hbs
+++ b/app/app/deprovision/template.hbs
@@ -1,1 +1,35 @@
-Deprovision {{model.handle}}
+<div class="row">
+  <div class="col-xs-12">
+    <div class="panel panel-default panel-subdued">
+      <div class="panel-heading">
+        <h3>Permanently deprovision {{model.handle}} </h3>
+      </div>
+      <div class="panel-body">
+        <form role="form">
+          {{#if error}}
+            <div class="alert alert-warning fade in">
+              <a class="close" data-dismiss="alert">×</a>
+              <p>
+                There was a problem deprovisioning your application: {{error.responseJSON.message}}
+              </p>
+            </div>
+          {{/if}}
+
+          <p>
+            This action CANNOT be undone. This will permanently deprovision
+            <strong>{{model.handle}}</strong>
+          </p>
+          <p>
+            <strong>Type the name of the app to permanently deprovision.</strong>
+          </p>
+          <div class="form-group">
+            {{#button-with-confirmation confirmValue=model.handle action='deprovision'}}
+              Deprovision Permanently
+            {{/button-with-confirmation}}
+          </div>
+        </form>
+
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/components/button-with-confirmation/component.js
+++ b/app/components/button-with-confirmation/component.js
@@ -1,0 +1,18 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  isConfirmed: null,
+  isUnconfirmed: Ember.computed.not('isConfirmed'),
+  input: function(){
+    var enteredValue = this.get('enteredValue');
+    var confirmValue = this.get('confirmValue');
+    this.set('isConfirmed', enteredValue === confirmValue);
+  }.on('init'),
+  actions: {
+    submit: function(){
+      if (this.get('isConfirmed')) {
+        this.sendAction();
+      }
+    }
+  }
+});

--- a/app/components/button-with-confirmation/template.hbs
+++ b/app/components/button-with-confirmation/template.hbs
@@ -1,0 +1,2 @@
+{{input classNameBindings=":form-control isConfirmed:confirmed:unconfirmed" value=enteredValue name="virtual-domain"}}
+<button {{bind-attr disabled=isUnconfirmed}} class="btn btn-danger" {{action 'submit'}}>{{yield}}</button>

--- a/app/models/app.js
+++ b/app/models/app.js
@@ -2,8 +2,9 @@ import DS from 'ember-data';
 import Ember from 'ember';
 
 var STATUSES = {
-  DEPROVISIONED: 'deprovisioned',
-  PROVISIONED:   'provisioned'
+  DEPROVISIONED:  'deprovisioned',
+  PROVISIONED:    'provisioned',
+  DEPROVISIONING: 'deprovisioning'
 };
 
 export default DS.Model.extend({

--- a/app/models/operation.js
+++ b/app/models/operation.js
@@ -6,5 +6,11 @@ export default DS.Model.extend({
   createdAt: DS.attr('string'),
   userName: DS.attr('string'),
   userEmail: DS.attr('string'),
-  diskSize: DS.attr('number')
+  diskSize: DS.attr('number'),
+
+  // append these values for a nested url. They are
+  // not actual attributes in the server payload, and
+  // as such ember-data `attrs`.
+  database: null,
+  app: null
 });

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -27,3 +27,4 @@
 @import "components/slider";
 @import "components/estimated-cost";
 @import "components/login-box";
+@import "components/button-with-confirmation";

--- a/app/styles/components/button-with-confirmation.scss
+++ b/app/styles/components/button-with-confirmation.scss
@@ -1,0 +1,6 @@
+input.unconfirmed {
+  border-color: #f00;
+  &:focus {
+    border-color: #f00;
+  }
+}

--- a/tests/acceptance/apps-deprovision-test.js
+++ b/tests/acceptance/apps-deprovision-test.js
@@ -1,0 +1,108 @@
+import Ember from 'ember';
+import startApp from '../helpers/start-app';
+import { stubRequest } from '../helpers/fake-server';
+
+var App;
+
+module('Acceptance: App Deprovision', {
+  setup: function() {
+    App = startApp();
+  },
+  teardown: function() {
+    Ember.run(App, 'destroy');
+  }
+});
+
+test('/apps/:id/deprovision requires authentication', function(){
+  expectRequiresAuthentication('/apps/1/deprovision');
+});
+
+test('/apps/:id/deprovision will not deprovision without confirmation', function(){
+  var appId = 1;
+  var appName = 'foo-bar';
+
+  stubApp({
+    id: appId,
+    handle: appName
+  });
+
+  signInAndVisit('/apps/'+appId+'/deprovision');
+  andThen(function(){
+    var button = findWithAssert('button:contains(Deprovision)');
+    ok(button.is(':disabled'), 'deprovision button is disabled');
+  });
+});
+
+test('/apps/:id/deprovision will deprovision with confirmation', function(){
+  var appId = 1;
+  var appName = 'foo-bar';
+  var didDeprovision = false;
+
+  stubStack({id: '1'});
+
+  stubApp({
+    id: appId,
+    handle: appName,
+    _links: {
+      account: {href: '/accounts/1'}
+    }
+  });
+
+  stubRequest('post', '/apps/'+appId+'/operations', function(request){
+    didDeprovision = true;
+    return this.success({
+      id: '1',
+      status: 'queued',
+      type: 'deprovision'
+    });
+  });
+
+  stubStacks();
+
+  signInAndVisit('/apps/'+appId+'/deprovision');
+  fillIn('input[type=text]', appName);
+  andThen(function(){
+    $('input[type=text]').trigger('input');
+  });
+  click('button:contains(Deprovision)');
+  andThen(function(){
+    ok(didDeprovision, 'deprovisioned');
+    equal(currentPath(), 'stacks.stack.apps.index');
+  });
+});
+
+test('/apps/:id/deprovision will show deprovision error', function(){
+  var appId = 1;
+  var appName = 'foo-bar';
+  var errorMessage = 'Some bad error';
+
+  stubStack({id: '1'});
+
+  stubApp({
+    id: appId,
+    handle: appName,
+    _links: {
+      account: {href: '/accounts/1'}
+    }
+  });
+
+  stubRequest('post', '/apps/'+appId+'/operations', function(request){
+    return this.error(401, {
+      code: 401,
+      error: 'invalid_credentials',
+      message: errorMessage
+    });
+  });
+
+  signInAndVisit('/apps/'+appId+'/deprovision');
+  fillIn('input[type=text]', appName);
+  andThen(function(){
+    $('input[type=text]').trigger('input');
+  });
+  click('button:contains(Deprovision)');
+  andThen(function(){
+    var error = findWithAssert('.alert');
+    ok(error.text().indexOf(errorMessage) > -1, 'error message shown');
+    equal(currentPath(), 'app.deprovision');
+  });
+});

--- a/tests/helpers/fake-server.js
+++ b/tests/helpers/fake-server.js
@@ -32,6 +32,13 @@ function successRequest(status, json){
   return [status, jsonMimeType, json];
 }
 
+function noContentRequest(status){
+  // if called without `status`
+  if (!status) { status = 204; }
+
+  return [status, jsonMimeType, ''];
+}
+
 function logHandledRequest(verb, path, request){
   console.log('[FakeServer] handled: ' + verb + ' ' + path, request);
 }
@@ -51,6 +58,7 @@ function stubRequest(verb, path, callback){
   var context = {
     json: jsonFromRequest,
     success: successRequest,
+    noContent: noContentRequest,
     error: errorRequest,
     notFound: notFoundRequest
   };

--- a/tests/unit/components/button-with-confirmation/component-test.js
+++ b/tests/unit/components/button-with-confirmation/component-test.js
@@ -1,0 +1,84 @@
+import Ember from "ember";
+import {
+  moduleForComponent,
+  test
+} from 'ember-qunit';
+
+moduleForComponent('button-with-confirmation', 'ButtonWithConfirmationComponent', {
+  // specify the other units that are required for this test
+  // needs: ['component:foo', 'helper:bar']
+});
+
+test('it confirms', function() {
+  var component = this.subject({
+    enteredValue: 'foo',
+    confirmValue: 'foo'
+  });
+
+  ok(component.get('isConfirmed'), 'is confirmed');
+});
+
+test('it is not confirmed', function() {
+  var component = this.subject({
+    enteredValue: 'foo',
+    confirmValue: 'boo'
+  });
+
+  ok(!component.get('isConfirmed'), 'is not confirmed');
+});
+
+test('input makes it confirmed', function() {
+  var component = this.subject({
+    confirmValue: 'boo'
+  });
+
+  this.append();
+
+  var input = component.$('input').val('boo');
+
+  ok(input.hasClass('unconfirmed'), 'is not confirmed');
+
+  input.val('boo');
+  input.trigger('input');
+
+  ok(input.hasClass('confirmed'), 'is confirmed');
+
+  input.val('foo');
+  input.trigger('input');
+
+  ok(input.hasClass('unconfirmed'), 'is not confirmed');
+});
+
+test('action is sent when confirmed', function() {
+  var actionCalled;
+  var component = this.subject({
+    enteredValue: 'foo',
+    confirmValue: 'foo',
+    action: 'save',
+    targetObject: {
+      save: function(){
+        actionCalled = true;
+      }
+    }
+  });
+
+  Ember.run(component, 'send', 'submit');
+  ok(actionCalled, 'action is triggered');
+});
+
+test('action is not sent when unconfirmed', function() {
+  var actionCalled;
+  var component = this.subject({
+    enteredValue: 'foo',
+    confirmValue: 'boo',
+    action: 'save',
+    targetObject: {
+      save: function(){
+        actionCalled = true;
+      }
+    }
+  });
+
+  Ember.run(component, 'send', 'submit');
+  ok(!actionCalled, 'action not is triggered');
+});


### PR DESCRIPTION
You can deprovision (destroy) an app. @fancyremarker this just destroys the app, let me know if this should be doing anything more fancy.

![](https://api.monosnap.com/rpc/file/download?id=gKPSCbf1tGdfYUSpCq1BdMNoMw65GN)
![](https://api.monosnap.com/rpc/file/download?id=78Kb809H2Y3DHyfxZUTSP0IAH2qIGd)
![](https://api.monosnap.com/rpc/file/download?id=J3bkSg6z7WWdt3ovC3bHWKM9kBtqjj)

Success takes you back to the stack view.