### PR TITLE
hal adapter -> 0.1.6

### DIFF
--- a/app/models/app.js
+++ b/app/models/app.js
@@ -15,5 +15,8 @@ export default DS.Model.extend({
   operations: DS.hasMany('operation', {async:true}),
   vhosts: DS.hasMany('vhost', {async:true}),
 
+  lastOperation: DS.belongsTo('operation', {async:true}),
+  lastDeployOperation: DS.belongsTo('operation', {async:true}),
+
   isDeprovisioned: Ember.computed.equal('status', STATUSES.DEPROVISIONED)
 });

--- a/app/serializers/application.js
+++ b/app/serializers/application.js
@@ -1,11 +1,28 @@
 import HalSerializer from "ember-data-hal-9000/serializer";
 
 export default HalSerializer.extend({
+  /*
+   * Overridden to remove top-level namespaces.
+   * The adapter would ordinarily return a hash like:
+   * `{user: {id: 1, ...}}` when serializing a user.
+   * Our API expects no top-level namespace so this is transformed into
+   * `{id: 1, ...}`
+   */
+  serializeIntoHash: function(hash, type, record, options){
+    var serialized = this.serialize(record, options);
 
-  attrs: {
-    stack: {
-      key: 'account'
+    for (var key in serialized) {
+      hash[key] = serialized[key];
     }
+  },
+
+  typeForRoot: function(typeKey){
+    var result = this._super(typeKey);
+    if (result === 'account') {
+      result = 'stack';
+    }
+
+    return result;
   },
 
   extractArray: function(store, primaryType, rawPayload) {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "ember-cli-pretender": "^0.3.1",
     "ember-cli-qunit": "0.1.2",
     "ember-data": "1.0.0-beta.12",
-    "ember-data-hal-9000": "^0.1.3",
+    "ember-data-hal-9000": "0.1.6",
     "ember-export-application-global": "^1.0.0",
     "ember-validations": "^2.0.0-alpha.1",
     "express": "^4.8.5",

--- a/tests/acceptance/apps-show-test.js
+++ b/tests/acceptance/apps-show-test.js
@@ -29,7 +29,7 @@ test('visiting /apps/my-app-id shows basic app info', function() {
     });
   });
 
-  signInAndVisit('/apps/my-app-id');
+  signInAndVisit('/apps/' + appId);
 
   andThen(function() {
     equal(currentPath(), 'app.services', 'show page is visited');
@@ -46,16 +46,18 @@ test('visiting /apps/my-app-id shows basic app info', function() {
 });
 
 test('visiting /apps/my-app-id when the app is deprovisioned', function() {
-  stubRequest('get', '/apps/my-app-id', function(request){
+  var appId = 'my-app-id';
+
+  stubRequest('get', '/apps/' + appId, function(request){
     ok(true, 'loads app');
     return this.success({
-      id: 'my-app',
+      id: appId,
       handle: 'my-app',
       status: 'deprovisioned'
     });
   });
 
-  signInAndVisit('/apps/my-app-id');
+  signInAndVisit('/apps/' + appId);
   andThen(function() {
     var deprovisionTitle = find('.resource-metadata-value:contains(Deprovisioned)');
     ok(deprovisionTitle.length, 'show deprovision title');
@@ -63,9 +65,11 @@ test('visiting /apps/my-app-id when the app is deprovisioned', function() {
 });
 
 test('visiting /apps/my-app-id/services shows services', function() {
-  stubRequest('get', '/apps/my-app-id', function(request){
+  var appId = 'my-app-id';
+
+  stubRequest('get', '/apps/' + appId, function(request){
     return this.success({
-      id: 'my-app-id',
+      id: appId,
       handle: 'my-app',
       _links: {
         services: { href: '/apps/my-app-id/services' }
@@ -97,7 +101,7 @@ test('visiting /apps/my-app-id/services shows services', function() {
     });
   });
 
-  signInAndVisit('/apps/my-app-id');
+  signInAndVisit('/apps/' + appId);
 
   andThen(function() {
     var servicesLink = find('a[href~="/apps/my-app-id/services"]');

--- a/tests/unit/models/app-test.js
+++ b/tests/unit/models/app-test.js
@@ -25,11 +25,13 @@ moduleForModel('app', 'App', {
 test('finding uses correct url', function(){
   expect(2);
 
-  stubRequest('get', '/apps/1', function(request){
+  var appId = 'my-app-id';
+
+  stubRequest('get', '/apps/' + appId, function(request){
     ok(true, 'calls with correct URL');
 
     return this.success({
-      id: 'my-app-id',
+      id: appId,
       handle: 'my-cool-app',
       _links: {
         account: { href: '/accounts/1' }
@@ -40,7 +42,7 @@ test('finding uses correct url', function(){
   var store = this.store();
 
   return Ember.run(function(){
-    return store.find('app', '1').then(function(){
+    return store.find('app', appId).then(function(){
       ok(true, 'app did find');
     });
   });

--- a/tests/unit/models/database-test.js
+++ b/tests/unit/models/database-test.js
@@ -25,12 +25,13 @@ moduleForModel('database', 'Database', {
 
 test('finding uses correct url', function(){
   expect(2);
+  var dbId = 'my-db-id';
 
-  stubRequest('get', '/databases/1', function(request){
+  stubRequest('get', '/databases/' + dbId, function(request){
     ok(true, 'calls with correct URL');
 
     return this.success({
-      id: 'my-database-id',
+      id: dbId,
       handle: 'my-cool-database',
       _links: {
         account: { href: '/accounts/1' }
@@ -41,7 +42,7 @@ test('finding uses correct url', function(){
   var store = this.store();
 
   return Ember.run(function(){
-    return store.find('database', '1').then(function(){
+    return store.find('database', dbId).then(function(){
       ok(true, 'database did find');
     });
   });


### PR DESCRIPTION
  
  * v0.1.5 removed the `serializeIntoHash` method, this PR adds it to the application serializer
  * v0.1.6 will load embedded resources with custom names, like
  * `lastOperation` and `lastDeployOperation` on app