### PR TITLE
Handle input

### DIFF
--- a/app/apps/new/template.hbs
+++ b/app/apps/new/template.hbs
@@ -20,7 +20,7 @@
               App handle
               <span class="label-helper">Lowercase alphanumerics, periods, and dashes only</span>
             </label>
-            {{input class="form-control app-handle" value=model.handle}}
+            {{handle-input class="form-control app-handle" value=model.handle}}
           </div>
         </form>
 
@@ -30,10 +30,10 @@
 </div>
 
 <div class="resource-actions">
-    <button class="btn btn-default" {{action 'cancel'}}>
-      Cancel
-    </button>
-    <button class="btn btn-primary" {{action 'create'}}>
-      Save App
-    </button>
+  <button class="btn btn-default" {{action 'cancel'}}>
+    Cancel
+  </button>
+  <button class="btn btn-primary" {{action 'create'}}>
+    Save App
+  </button>
 </div>

--- a/app/components/handle-input/component.js
+++ b/app/components/handle-input/component.js
@@ -1,0 +1,17 @@
+import Ember from 'ember';
+
+export default Ember.TextField.extend({
+  _dasherizedValue: null,
+  value: Ember.computed(function(key, value){
+    if (arguments.length > 1) {
+      if (value && typeof value === 'string') {
+        this._dasherizedValue = value.dasherize();
+      } else {
+        this._dasherizedValue = value;
+      }
+      return this._dasherizedValue;
+    } else {
+      return this._dasherizedValue;
+    }
+  })
+});

--- a/app/databases/new/template.hbs
+++ b/app/databases/new/template.hbs
@@ -24,11 +24,10 @@
           </div>
 
           <div class="form-group">
-            {{input class="database-name form-control sanitize-handler"
+            {{handle-input class="database-name form-control sanitize-handler"
                     placeholder="e.g., postgresql-prod"
                     name="handle"
-                    value=model.handle
-                    }}
+                    value=model.handle}}
           </div>
 
           <div class="form-group">

--- a/app/stacks/index/route.js
+++ b/app/stacks/index/route.js
@@ -4,6 +4,10 @@ export default Ember.Route.extend({
   redirect: function(){
     var stacks = this.modelFor('stacks');
     var stack = stacks.objectAt(0);
-    this.replaceWith('apps', stack);
+    if (stack) {
+      this.replaceWith('apps', stack);
+    } else {
+      this.replaceWith('welcome.first-app');
+    }
   }
 });

--- a/app/welcome/first-app/template.hbs
+++ b/app/welcome/first-app/template.hbs
@@ -16,7 +16,7 @@
                 Lowercase alphanumerics only
               </span>
             </label>
-            {{input class="app-name form-control sanitize-handler"
+            {{handle-input class="app-name form-control sanitize-handler"
               placeholder="e.g., app-prod"
               name="app-handle"
               value=model.appHandle
@@ -42,7 +42,7 @@
                   Lowercase alphanumerics only
                 </span>
               </label>
-              {{input class="database-name form-control sanitize-handler"
+              {{handle-input class="database-name form-control sanitize-handler"
                     placeholder="e.g., postgresql-prod"
                     name="db-handle"
                     value=model.dbHandle

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "diesel",
   "dependencies": {
     "jquery": "^1.11.1",
-    "ember": "1.11.0-beta.2",
+    "ember": "1.10.0",
     "ember-data": "1.0.0-beta.15",
     "ember-resolver": "~0.1.11",
     "loader.js": "ember-cli/loader.js#1.0.1",

--- a/config/environment.js
+++ b/config/environment.js
@@ -39,8 +39,9 @@ module.exports = function(environment) {
     contentSecurityPolicy: {
       'connect-src': "'self' http://localhost:4000 http://localhost:4001 ws://localhost:35729 ws://0.0.0.0:35729 http://api.mixpanel.com http://api.segment.io",
       'style-src': "'self' 'unsafe-inline' http://use.typekit.net",
-      'img-src': "'self' http://www.gravatar.com https://secure.gravatar.com http://www.google-analytics.com http://p.typekit.net",
-      'script-src': "'self' https://js.stripe.com https://api.stripe.com http://use.typekit.net"
+      'img-src': "'self' http://www.gravatar.com https://secure.gravatar.com http://www.google-analytics.com http://p.typekit.net https://track.customer.io",
+      'script-src': "'self' 'unsafe-inline' https://js.stripe.com https://api.stripe.com http://use.typekit.net http://cdn.segment.com https://assets.customer.io http://www.google-analytics.com http://cdn.mxpnl.com",
+      'font-src': "'self' 'unsafe-inline'"
     }
 
   };

--- a/tests/acceptance/landing-page-test.js
+++ b/tests/acceptance/landing-page-test.js
@@ -6,7 +6,6 @@ var App;
 module('Acceptance: LandingPage', {
   setup: function() {
     App = startApp();
-    stubStacks();
   },
   teardown: function() {
     Ember.run(App, 'destroy');
@@ -14,6 +13,7 @@ module('Acceptance: LandingPage', {
 });
 
 test('visiting / redirects to login page', function() {
+  stubStacks();
   visit('/');
 
   andThen(function() {
@@ -22,9 +22,19 @@ test('visiting / redirects to login page', function() {
 });
 
 test('visiting / when logged in redirects to first stack page', function() {
+  stubStacks();
   signInAndVisit('/');
 
   andThen(function() {
     equal(currentPath(), 'stacks.stack.apps.index');
+  });
+});
+
+test('visiting / signed in with no account directs to welcome', function() {
+  stubStacks({}, []);
+  signInAndVisit('/');
+
+  andThen(function() {
+    equal(currentPath(), 'welcome.first-app');
   });
 });

--- a/tests/helpers/aptible-helpers.js
+++ b/tests/helpers/aptible-helpers.js
@@ -97,7 +97,7 @@ Ember.Test.registerHelper('stubApp', function(app, appData){
   });
 });
 
-Ember.Test.registerHelper('stubStacks', function(app, options){
+Ember.Test.registerHelper('stubStacks', function(app, options, stacks){
   if (!options) { options = {}; }
   if (options.includeApps === undefined) {
     options.includeApps = true;
@@ -106,27 +106,29 @@ Ember.Test.registerHelper('stubStacks', function(app, options){
     options.includeDatabases = true;
   }
 
+  stacks = stacks || [{
+    _links: {
+      self: { href: '...' },
+      apps: { href: '/accounts/my-stack-1/apps' },
+      databases: { href: '/accounts/my-stack-1/databases' }
+    },
+    id: 1,
+    handle: 'my-stack-1'
+  }, {
+    _links: {
+      self: { href: '...' },
+      apps: { href: '/accounts/my-stack-2/apps' },
+      databases: { href: '/accounts/my-stack-2/databases' }
+    },
+    id: 2,
+    handle: 'my-stack-2'
+  }];
+
   stubRequest('get', '/accounts', function(request){
     return this.success({
       _links: {},
       _embedded: {
-        accounts: [{
-          _links: {
-            self: { href: '...' },
-            apps: { href: '/accounts/my-stack-1/apps' },
-            databases: { href: '/accounts/my-stack-1/databases' }
-          },
-          id: 1,
-          handle: 'my-stack-1'
-        }, {
-          _links: {
-            self: { href: '...' },
-            apps: { href: '/accounts/my-stack-2/apps' },
-            databases: { href: '/accounts/my-stack-2/databases' }
-          },
-          id: 2,
-          handle: 'my-stack-2'
-        }]
+        accounts: stacks
       }
     });
   });

--- a/tests/unit/components/handle-input/component-test.js
+++ b/tests/unit/components/handle-input/component-test.js
@@ -1,0 +1,39 @@
+import Ember from "ember";
+import {
+  moduleForComponent,
+  test
+} from 'ember-qunit';
+
+moduleForComponent('handle-input', {
+  // specify the other units that are required for this test
+  // needs: ['component:foo', 'helper:bar']
+});
+
+test('entering value with spaces adds dashes', function(assert) {
+  assert.expect(2);
+
+  var component = this.subject();
+  var element = this.append();
+
+  var input = Ember.$(element, 'input');
+
+  input.val('new val');
+  input.trigger('input');
+
+  assert.equal(input.val(), 'new-val');
+  assert.equal(component.get('value'), 'new-val');
+});
+
+test('setting value with spaces adds dashes', function(assert) {
+  assert.expect(2);
+
+  var component = this.subject();
+  var element = this.append();
+
+  var input = Ember.$(element, 'input');
+
+  Ember.run(component, 'set', 'value', 'new val');
+
+  assert.equal(input.val(), 'new-val');
+  assert.equal(component.get('value'), 'new-val');
+});

--- a/tests/unit/initializers/setup-torii-with-store-test.js
+++ b/tests/unit/initializers/setup-torii-with-store-test.js
@@ -6,7 +6,7 @@ var container, application;
 module('SetupToriiWithStoreInitializer', {
   setup: function() {
     Ember.run(function() {
-      container = new Ember.Container(new Ember.Registry());
+      container = new Ember.Container();
       application = Ember.Application.create();
       application.deferReadiness();
     });


### PR DESCRIPTION
Add dashes to handle input. On app, db, and first-app app/db creation. Closes https://github.com/aptible/diesel.aptible.com/issues/89.

![](http://g.recordit.co/KrX28d08Tz.gif)

Also includes some cleanup for CSP headers and a reversion to Ember 1.10. Ember beta and canary seem to have an issue with pushing the cursor to the end of the line even when the value does not change. See https://github.com/emberjs/ember.js/issues/10481.