### PR TITLE
show a checklist for a non-deployed app

### DIFF
--- a/app/app/deploy/controller.js
+++ b/app/app/deploy/controller.js
@@ -1,0 +1,2 @@
+import Ember from 'ember';
+export default Ember.Controller.extend({});

--- a/app/app/deploy/route.js
+++ b/app/app/deploy/route.js
@@ -1,0 +1,22 @@
+import Ember from "ember";
+import config from '../../config/environment';
+
+let gettingStartedDocs = config.externalUrls.gettingStartedDocs;
+
+export default Ember.Route.extend({
+  model: function(){
+    let app = this.modelFor('app');
+    let currentUser = this.session.get('currentUser');
+
+    return Ember.RSVP.hash({
+      app: app,
+      sshKeys: currentUser.get('sshKeys')
+    });
+  },
+
+  setupController: function(controller, model){
+    controller.set('model', model.app);
+    controller.set('sshKeys', model.sshKeys);
+    controller.set('gettingStartedDocs', gettingStartedDocs);
+  }
+});

--- a/app/app/deploy/template.hbs
+++ b/app/app/deploy/template.hbs
@@ -1,0 +1,68 @@
+<div class="row">
+  <div class="col-xs-10 col-xs-offset-1">
+    <div class="first-time-app-deploy">
+      <h2>Deploy undeployed-test in 3 easy steps</h2>
+      <div class="panel panel-default panel-steps">
+        <div class="panel-step">
+          <div class="panel-step-num">
+            {{#if sshKeys.length}}
+              <i class="fa fa-check success"></i>
+            {{else}}
+              <h3>1</h3>
+            {{/if}}
+          </div>
+
+          <div class="panel-step-info">
+            <h3>Add your SSH Key</h3>
+
+            {{#if sshKeys.length}}
+              <p>
+              Great, with an SSH key on your Aptible account, you're ready to deploy your app.
+              </p>
+            {{else}}
+              <p>
+                 Aptible uses your SSH key to authenticate you when deploying your app.
+                 To learn more about generating your SSH key,
+                 <a {{bind-attr href=gettingStartedDocs}}>check out our guides</a>.
+              </p>
+
+              <div class="panel-step-cta">
+                {{link-to 'Add your SSH Key' 'settings.ssh' class='btn btn-primary'}}
+              </div>
+            {{/if}}
+          </div>
+        </div>
+
+        <div class="panel-step">
+          <div class="panel-step-num">
+            <h3>2</h3>
+          </div>
+
+          <div class="panel-step-info">
+            <h3>Add a Procfile to your App</h3>
+            <p>
+               Aptible uses your app’s Procfile to configure which services
+               to run on your app.  You can read more about creating a
+               Procfile in <a {{bind-attr href=gettingStartedDocs}}>Getting Started Guides</a>.
+            </p>
+          </div>
+        </div>
+
+        <div class="panel-step">
+          <div class="panel-step-num">
+            <h3>3</h3>
+          </div>
+
+          <div class="panel-step-info">
+            <h3>Git Push to Aptible</h3>
+
+            <div class="code-block">
+              <code>git remote add aptible {{model.gitRepo}}</code>
+              <code>git push aptible master</code>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/app/index/route.js
+++ b/app/app/index/route.js
@@ -2,6 +2,12 @@ import Ember from 'ember';
 
 export default Ember.Route.extend({
   redirect: function(){
-    this.replaceWith('app.services');
+    let app = this.modelFor('app');
+
+    if (app.get('hasBeenDeployed')) {
+      this.replaceWith('app.services');
+    } else {
+      this.replaceWith('app.deploy');
+    }
   }
 });

--- a/app/models/app.js
+++ b/app/models/app.js
@@ -2,6 +2,7 @@ import DS from 'ember-data';
 import Ember from 'ember';
 
 var STATUSES = {
+  PENDING:  'pending',
   DEPROVISIONED:  'deprovisioned',
   PROVISIONED:    'provisioned',
   DEPROVISIONING: 'deprovisioning'
@@ -11,7 +12,7 @@ export default DS.Model.extend({
   // properties
   handle: DS.attr('string'),
   gitRepo: DS.attr('string'),
-  status: DS.attr('string', {defaultValue: STATUSES.PROVISIONED}),
+  status: DS.attr('string', {defaultValue: STATUSES.PENDING}),
   createdAt: DS.attr('iso-8601-timestamp'),
 
   // relationships
@@ -26,5 +27,7 @@ export default DS.Model.extend({
   // computed properties
   isDeprovisioned: Ember.computed.equal('status', STATUSES.DEPROVISIONED),
   isDeprovisioning: Ember.computed.equal('status', STATUSES.DEPROVISIONING),
-  isRunning: Ember.computed.equal('status', STATUSES.PROVISIONED)
+  isRunning: Ember.computed.equal('status', STATUSES.PROVISIONED),
+  isPending: Ember.computed.equal('status', STATUSES.PENDING),
+  hasBeenDeployed: Ember.computed.not('isPending')
 });

--- a/app/router.js
+++ b/app/router.js
@@ -18,6 +18,7 @@ Router.map(function() {
     });
     this.route("activity");
     this.route("deprovision");
+    this.route("deploy");
   });
 
   this.route("database", {

--- a/app/styles/specific_resources/apps.scss
+++ b/app/styles/specific_resources/apps.scss
@@ -44,3 +44,11 @@
     font-size: 11px;
   }
 }
+
+.first-time-app-deploy {
+  h2 {
+    font-size: 24px;
+    text-align: center;
+    margin: 30px 0;
+  }
+}

--- a/app/templates/app/-nav.hbs
+++ b/app/templates/app/-nav.hbs
@@ -1,10 +1,18 @@
 <ul class="nav nav-pills resource-navigation">
-  {{#link-to "app.services" tagName="li"}}
-    {{link-to "Services" "app.services"}}
-  {{/link-to}}
-  {{#link-to "app.vhosts" tagName="li"}}
-    {{link-to "Domains" "app.vhosts"}}
-  {{/link-to}}
+  {{#if model.hasBeenDeployed}}
+    {{#link-to "app.services" tagName="li"}}
+      {{link-to "Services" "app.services"}}
+    {{/link-to}}
+
+    {{#link-to "app.vhosts" tagName="li"}}
+      {{link-to "Domains" "app.vhosts"}}
+    {{/link-to}}
+  {{else}}
+    {{#link-to "app.deploy" tagName="li"}}
+      {{link-to "Deploy" "app.deploy"}}
+    {{/link-to}}
+  {{/if}}
+
   {{#link-to "app.activity" tagName="li"}}
     {{link-to "Activity" "app.activity"}}
   {{/link-to}}

--- a/config/environment.js
+++ b/config/environment.js
@@ -20,6 +20,10 @@ module.exports = function(environment) {
 
     segmentioKey: 'qxwhj8ys4t',
 
+    externalUrls: {
+      gettingStartedDocs: 'https://support.aptible.com/hc/en-us/articles/202638630-Deploying-your-first-app'
+    },
+
     EmberENV: {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -58,7 +58,9 @@
     "clickPrevPageLink",
     "locationUpdatedTo",
     "setNoUISlider",
-    "slideNoUISlider"
+    "slideNoUISlider",
+    "expectLink",
+    "expectNoLink"
   ],
   "node": false,
   "browser": false,

--- a/tests/acceptance/apps/basic-test.js
+++ b/tests/acceptance/apps/basic-test.js
@@ -45,9 +45,7 @@ test('visiting /stacks/1/apps then clicking on an app visits the app', function(
   signInAndVisit('/stacks/1/apps');
 
   andThen(function(){
-    var appLink = find('a[href~="/apps/1"]');
-    ok(appLink.length, 'has link to app 1');
-
+    let appLink = expectLink("/apps/1");
     click(appLink);
   });
 

--- a/tests/acceptance/apps/basic-test.js
+++ b/tests/acceptance/apps/basic-test.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
-import startApp from '../helpers/start-app';
-import { stubRequest } from '../helpers/fake-server';
+import startApp from '../../helpers/start-app';
+import { stubRequest } from '../../helpers/fake-server';
 
 var App, server;
 

--- a/tests/acceptance/apps/create-test.js
+++ b/tests/acceptance/apps/create-test.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
-import startApp from '../helpers/start-app';
-import { stubRequest } from '../helpers/fake-server';
+import startApp from '../../helpers/start-app';
+import { stubRequest } from '../../helpers/fake-server';
 
 var App;
 

--- a/tests/acceptance/apps/deprovision-test.js
+++ b/tests/acceptance/apps/deprovision-test.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
-import startApp from '../helpers/start-app';
-import { stubRequest } from '../helpers/fake-server';
+import startApp from '../../helpers/start-app';
+import { stubRequest } from '../../helpers/fake-server';
 
 var App;
 

--- a/tests/acceptance/apps/paginated-operations-test.js
+++ b/tests/acceptance/apps/paginated-operations-test.js
@@ -1,13 +1,13 @@
-import { stubRequest } from '../helpers/fake-server';
+import { stubRequest } from '../../helpers/fake-server';
 import {
   paginatedResourceQueryParamsPage2Test,
   paginatedResourceUpdatesQueryParamsTest,
   resourceOperationsTest,
   paginatedResourceTest
-} from '../helpers/shared-tests';
+} from '../../helpers/shared-tests';
 
 import Ember from 'ember';
-import startApp from '../helpers/start-app';
+import startApp from '../../helpers/start-app';
 
 var App;
 

--- a/tests/acceptance/apps/services-test.js
+++ b/tests/acceptance/apps/services-test.js
@@ -30,8 +30,7 @@ test('app show page includes link to services url', function(){
   signInAndVisit(appUrl);
 
   andThen(function(){
-    ok(find('a[href~="' + appServicesUrl + '"]').length,
-       'has link to ' + appServicesUrl);
+    expectLink(appServicesUrl);
   });
 });
 

--- a/tests/acceptance/apps/services-test.js
+++ b/tests/acceptance/apps/services-test.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
-import startApp from '../helpers/start-app';
-import { stubRequest } from '../helpers/fake-server';
+import startApp from '../../helpers/start-app';
+import { stubRequest } from '../../helpers/fake-server';
 
 var App;
 
@@ -23,7 +23,8 @@ test(appServicesUrl + ' requires authentication', function(){
 
 test('app show page includes link to services url', function(){
   stubApp({
-    id: appId
+    id: appId,
+    status: 'provisioned'
   });
 
   signInAndVisit(appUrl);

--- a/tests/acceptance/apps/show-empty-test.js
+++ b/tests/acceptance/apps/show-empty-test.js
@@ -1,0 +1,122 @@
+import Ember from 'ember';
+import startApp from '../../helpers/start-app';
+import { stubRequest } from '../../helpers/fake-server';
+import config from 'diesel/config/environment';
+
+let App;
+let appId = 'app-id';
+let url =`/apps/${appId}`;
+let gitRepo = 'git@aptible.com:my-app.git';
+let gettingStartedLink = config.externalUrls.gettingStartedDocs;
+
+module('Acceptance: Apps Show - Never deployed (app.status === "pending")', {
+  setup: function() {
+    App = startApp();
+  },
+  teardown: function() {
+    Ember.run(App, 'destroy');
+  }
+});
+
+function setupAjaxStubs(sshKeys){
+  stubRequest('get', '/apps/:app_id', function(request){
+    return this.success({
+      id: request.params.app_id,
+      status: 'pending',
+      git_repo: gitRepo
+    });
+  });
+
+  stubRequest('get', '/users/:user_id/ssh_keys', function(request){
+    return this.success({ _embedded: { ssh_keys: sshKeys } });
+  });
+}
+
+function findStep(index){
+  return find('.panel-step:eq(' + index + ')');
+}
+
+function expectTab(tabName){
+  if (!findTab(tabName).length) {
+    ok(false, `Could not find tab named ${tabName}`);
+  } else {
+    ok(true, `Found tab named ${tabName}`);
+  }
+}
+
+function findTab(tabName){
+  return find(`.resource-navigation li:contains(${tabName})`);
+}
+
+function expectNoTab(tabName){
+  if (findTab(tabName).length) {
+    ok(false, `Expected not to find tab ${tabName}`);
+  } else {
+    ok(true, `Found no tab ${tabName}`);
+  }
+}
+
+test(`visit ${url} when app has not been deployed`, function(assert){
+  let sshKeys = [];
+  setupAjaxStubs(sshKeys);
+
+  signInAndVisit(url);
+  andThen(function(){
+    equal(currentPath(), 'app.deploy');
+
+    // displayed tabs
+    expectTab('Deploy');
+    expectTab('Activity');
+    expectTab('Deprovision');
+
+    // hidden tabs
+    expectNoTab('Services');
+    expectNoTab('Domains');
+
+    // displayed steps
+    let steps = [
+      {title: 'Add your SSH Key', links: ['settings/ssh', gettingStartedLink]},
+      {title: 'Add a Procfile to your App', links:[gettingStartedLink]},
+      {title: 'Git Push to Aptible', contains: [gitRepo]}
+    ];
+
+    steps.forEach(function(step, i){
+      let stepEl = findStep(i);
+
+      let title = stepEl.find(`:contains(${step.title})`);
+      ok(title.length, `has title ${step.title} in position ${i}`);
+
+      ok( stepEl.find(`.panel-step-num:contains(${i+1})`).length,
+          `panel at position ${i} has number ${i+1}`);
+
+      if (step.contains) {
+        step.contains.forEach(function(text){
+          ok( stepEl.find(`*:contains(${text})`).length,
+              `step ${i} contains "${text}"`);
+        });
+      }
+
+      if (step.links) {
+        step.links.forEach(function(link){
+          expectLink(link, {context:stepEl});
+        });
+      }
+    });
+  });
+});
+
+test(`visit ${url} when user has ssh keys`, function(assert){
+  let sshKeys = [ {id: 'ssh-key-1'} ];
+  setupAjaxStubs(sshKeys);
+
+  signInAndVisit(url);
+  andThen(function(){
+    let sshKeyStep = findStep(0);
+    let sshKeyNumber = sshKeyStep.find('.panel-step-num');
+
+    ok( sshKeyNumber.find('i.fa-check').length,
+        'ssh key step number has checkmark');
+
+    expectNoLink('settings/ssh', {context: sshKeyStep});
+  });
+});

--- a/tests/acceptance/apps/show-test.js
+++ b/tests/acceptance/apps/show-test.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
-import startApp from '../helpers/start-app';
-import { stubRequest } from '../helpers/fake-server';
+import startApp from '../../helpers/start-app';
+import { stubRequest } from '../../helpers/fake-server';
 
 var App;
 
@@ -28,6 +28,7 @@ test('visiting /apps/my-app-id shows basic app info', function() {
     return this.success({
       id: appId,
       handle: 'my-app',
+      status: 'provisioned',
       _embedded: {
         services: [],
         lastDeployOperation: {
@@ -99,6 +100,7 @@ test('visiting /apps/my-app-id/services shows services', function() {
     return this.success({
       id: appId,
       handle: 'my-app',
+      status: 'provisioned',
       _links: {
         services: { href: '/apps/my-app-id/services' }
       }

--- a/tests/acceptance/apps/show-test.js
+++ b/tests/acceptance/apps/show-test.js
@@ -53,11 +53,8 @@ test('visiting /apps/my-app-id shows basic app info', function() {
     let app = find('.resource-title:contains(my-app)');
     ok(app.length, 'shows app handle');
 
-    let linkToOperations = find('a[href~="/apps/my-app-id/activity"]');
-    ok(linkToOperations.length, 'links to activity');
-
-    let linkToVhosts = find('a[href~="/apps/my-app-id/vhosts"]');
-    ok(linkToVhosts.length, 'links to vhosts');
+    expectLink("/apps/my-app-id/activity");
+    expectLink("/apps/my-app-id/vhosts");
 
     let lastDeployedBy = findWithAssert('.last-deployed-by');
     let expectedDate = 'February 15, 2015';
@@ -134,9 +131,7 @@ test('visiting /apps/my-app-id/services shows services', function() {
   signInAndVisit('/apps/' + appId);
 
   andThen(function() {
-    var servicesLink = find('a[href~="/apps/my-app-id/services"]');
-    ok(servicesLink.length, 'has link to services');
-
+    let servicesLink = expectLink("/apps/my-app-id/services");
     click(servicesLink);
   });
 

--- a/tests/acceptance/apps/vhost-new-test.js
+++ b/tests/acceptance/apps/vhost-new-test.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
-import startApp from '../helpers/start-app';
-import { stubRequest } from '../helpers/fake-server';
+import startApp from '../../helpers/start-app';
+import { stubRequest } from '../../helpers/fake-server';
 
 var App;
 

--- a/tests/acceptance/apps/vhosts-test.js
+++ b/tests/acceptance/apps/vhosts-test.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
-import startApp from '../helpers/start-app';
-import { stubRequest } from '../helpers/fake-server';
+import startApp from '../../helpers/start-app';
+import { stubRequest } from '../../helpers/fake-server';
 
 var App;
 
@@ -25,7 +25,8 @@ test(appVhostsUrl + ' requires authentication', function(){
 
 test('app show page includes link to vhosts url', function(){
   stubApp({
-    id: appId
+    id: appId,
+    status: 'provisioned'
   });
 
   signInAndVisit(appUrl);

--- a/tests/acceptance/apps/vhosts-test.js
+++ b/tests/acceptance/apps/vhosts-test.js
@@ -32,8 +32,7 @@ test('app show page includes link to vhosts url', function(){
   signInAndVisit(appUrl);
 
   andThen(function(){
-    ok(find('a[href~="' + appVhostsUrl + '"]').length,
-       'has link to ' + appVhostsUrl);
+    expectLink(appVhostsUrl);
   });
 });
 

--- a/tests/helpers/aptible-helpers.js
+++ b/tests/helpers/aptible-helpers.js
@@ -257,7 +257,7 @@ Ember.Test.registerAsyncHelper('setNoUISlider', function(app, selector, value){
 });
 
 Ember.Test.registerHelper('expectLink', function(app, link, options) {
-  let contextEl = options.context;
+  let contextEl = (options || {}).context;
   let selector = `*[href*="${link}"]`;
   let linkEl;
   if (contextEl) {
@@ -268,13 +268,14 @@ Ember.Test.registerHelper('expectLink', function(app, link, options) {
 
   if (linkEl.length) {
     ok(true, `Found link "${link}"`);
+    return linkEl;
   } else {
     ok(false, `Did not find link "${link}"`);
   }
 });
 
 Ember.Test.registerHelper('expectNoLink', function(app, link, options) {
-  let contextEl = options.context;
+  let contextEl = (options || {}).context;
   let selector = `*[href*="${link}"]`;
   let linkEl;
   if (contextEl) {

--- a/tests/helpers/aptible-helpers.js
+++ b/tests/helpers/aptible-helpers.js
@@ -172,6 +172,7 @@ Ember.Test.registerHelper('stubStacks', function(app, options, stacks){
           apps: [{
             id: 1,
             handle: 'my-app-1-stack-1',
+            status: 'provisioned',
             _embedded: {
               services: [{
                 id: '1',
@@ -182,6 +183,7 @@ Ember.Test.registerHelper('stubStacks', function(app, options, stacks){
           }, {
             id: 2,
             handle: 'my-app-2-stack-1',
+            status: 'provisioned',
             _embedded: {
               services: [{
                 id: '2',
@@ -200,12 +202,14 @@ Ember.Test.registerHelper('stubStacks', function(app, options, stacks){
           apps: [{
             id: 3,
             handle: 'my-app-1-stack-2',
+            status: 'provisioned',
             _embedded: {
               services: []
             }
           }, {
             id: 4,
             handle: 'my-app-2-stack-2',
+            status: 'provisioned',
             _embedded: {
               services: []
             }
@@ -249,5 +253,39 @@ Ember.Test.registerAsyncHelper('setNoUISlider', function(app, selector, value){
   var element = $(selector);
   if (element && element.length) {
     element.trigger('set', value);
+  }
+});
+
+Ember.Test.registerHelper('expectLink', function(app, link, options) {
+  let contextEl = options.context;
+  let selector = `*[href*="${link}"]`;
+  let linkEl;
+  if (contextEl) {
+    linkEl = contextEl.find(selector);
+  } else {
+    linkEl = find(selector);
+  }
+
+  if (linkEl.length) {
+    ok(true, `Found link "${link}"`);
+  } else {
+    ok(false, `Did not find link "${link}"`);
+  }
+});
+
+Ember.Test.registerHelper('expectNoLink', function(app, link, options) {
+  let contextEl = options.context;
+  let selector = `*[href*="${link}"]`;
+  let linkEl;
+  if (contextEl) {
+    linkEl = contextEl.find(selector);
+  } else {
+    linkEl = find(selector);
+  }
+
+  if (linkEl.length) {
+    ok(false, `Expected not to find link "${link}"`);
+  } else {
+    ok(true, `Did not find link "${link}"`);
   }
 });


### PR DESCRIPTION
@mixonic, for you

  * Adds 'pending' status type, `hasBeenDeployed` CP for app model
  * display checklist on app show page if app has not been deployed

fixes #78 

Also:

  * rename some acceptance test files to put 'app' related tests together

This makes it so that a never-been-deployed app is shown a screen with a checklist that looks like this:
![image](https://cloud.githubusercontent.com/assets/2023/6235083/c62badfc-b6ad-11e4-801c-132e2a62dbde.png)

or, if the user has no ssh keys:

![image](https://cloud.githubusercontent.com/assets/2023/6235090/d25f81e8-b6ad-11e4-99e3-6ae329f6915d.png)


This is ready to merge, but it will not work properly until the API returns a 'pending' status for never-been-successfully-deployed apps. I'm making a PR for that now.
