### PR TITLE
Test that cancel/click exit from app/db create rolls back model

### DIFF
--- a/app/apps/new/template.hbs
+++ b/app/apps/new/template.hbs
@@ -20,7 +20,7 @@
               App handle
               <span class="label-helper">Lowercase alphanumerics, periods, and dashes only</span>
             </label>
-            {{handle-input class="form-control app-handle" value=model.handle}}
+            {{handle-input class="form-control" value=model.handle name='handle'}}
           </div>
         </form>
 

--- a/app/databases/new/route.js
+++ b/app/databases/new/route.js
@@ -14,6 +14,10 @@ export default Ember.Route.extend({
   },
 
   actions: {
+    willTransition: function(){
+      this.currentModel.rollback();
+    },
+
     create: function(){
       var db = this.currentModel,
           route = this,
@@ -37,9 +41,6 @@ export default Ember.Route.extend({
     },
 
     cancel: function(){
-      var db = this.currentModel;
-
-      db.rollback();
       this.transitionTo('databases.index');
     }
   }

--- a/app/templates/stack/-app.hbs
+++ b/app/templates/stack/-app.hbs
@@ -1,7 +1,7 @@
 {{#link-to 'app' app class="panel-link"}}
   <div class="panel panel-default panel-subdued app resource-list-item">
     <div class="panel-heading">
-      <h5>{{app.handle}}</h5>
+      <h5 class='app-handle'>{{app.handle}}</h5>
     </div>
     <div class="panel-body">
 

--- a/app/templates/stack/-db.hbs
+++ b/app/templates/stack/-db.hbs
@@ -1,7 +1,7 @@
 {{#link-to 'database' database class="panel-link"}}
   <div class="panel panel-default panel-subdued resource-list-item database">
     <div class="panel-heading">
-      <h5>{{database.handle}}</h5>
+      <h5 class='database-handle'>{{database.handle}}</h5>
     </div>
     <div class="panel-body">
       <span class="service-badge">

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -63,7 +63,11 @@
     "setNoUISlider",
     "slideNoUISlider",
     "expectLink",
-    "expectNoLink"
+    "expectNoLink",
+    "findInput",
+    "expectInput",
+    "findButton",
+    "expectButton"
   ],
   "node": false,
   "browser": false,

--- a/tests/helpers/aptible-helpers.js
+++ b/tests/helpers/aptible-helpers.js
@@ -325,3 +325,39 @@ Ember.Test.registerHelper('expectNoLink', function(app, link, options) {
     ok(true, `Did not find link "${link}"`);
   }
 });
+
+Ember.Test.registerHelper('findButton', function(app, buttonName, options) {
+  let context = (options || {}).context;
+
+  let selector = `button:contains(${buttonName})`;
+  let el = context ? context.find(selector) : find(selector);
+
+  return el;
+});
+
+Ember.Test.registerHelper('expectButton', function(app, buttonName, options) {
+  let el = findButton(buttonName, options);
+  if (el.length) {
+    ok(true, `Found ${el.length} of button "${buttonName}"`);
+  } else {
+    ok(false, `Found 0 of button "${buttonName}"`);
+  }
+});
+
+Ember.Test.registerHelper('findInput', function(app, inputName, options) {
+  let context = (options || {}).context;
+
+  let selector = `input[name="${inputName}"]`;
+  let el = context ? context.find(selector) : find(selector);
+
+  return el;
+});
+
+Ember.Test.registerHelper('expectInput', function(app, inputName, options) {
+  let el = findInput(inputName, options);
+  if (el.length) {
+    ok(true, `Found ${el.length} of input "${inputName}"`);
+  } else {
+    ok(false, `Found 0 of input "${inputName}"`);
+  }
+});


### PR DESCRIPTION
fixes #80

@sandersonet, for you. This uses the `willTransition` hook to roll
back the app/db from the app/db 'new' pages.

Cleaned up the app/db acceptance tests a little and added two new tests
that after transitioning away from an in-progress app/db creation that
app/db doesn't show up on the index page.

cc @mixonic