### PR TITLE
Signup

### DIFF
--- a/app/components/select-plan/template.hbs
+++ b/app/components/select-plan/template.hbs
@@ -1,1 +1,1 @@
-{{view "select" content=plans value=value class="form-control" prompt="Select a plan" name=name}}
+{{view "select" content=plans value=value class="form-control" name=name}}

--- a/app/models/database.js
+++ b/app/models/database.js
@@ -1,4 +1,5 @@
 import DS from 'ember-data';
+import Ember from 'ember';
 
 export default DS.Model.extend({
   name: DS.attr('string'),
@@ -11,3 +12,20 @@ export default DS.Model.extend({
   stack: DS.belongsTo('stack', {async: true}),
   operations: DS.hasMany('operation', {async:true})
 });
+
+export function provisionDatabases(user, store){
+  if (!user.get('verified')) { return Ember.RSVP.resolve(); }
+
+  return store.find('database').then( function(databases) {
+    let promises = databases.map(function(database){
+      let op = store.createRecord('operation', {
+        type: 'provision',
+        diskSize: '10', // FIXME
+        database: database
+      });
+      return op.save();
+    });
+
+    return Ember.RSVP.all(promises);
+  });
+}

--- a/app/models/stack.js
+++ b/app/models/stack.js
@@ -9,6 +9,7 @@ export default DS.Model.extend({
   type: DS.attr('string'),
   syslogHost: DS.attr('string'),
   syslogPort: DS.attr('string'),
+  organizationUrl: DS.attr('string'),
 
   // relationships
   apps: DS.hasMany('app', {async: true}),
@@ -18,7 +19,7 @@ export default DS.Model.extend({
   logDrains: DS.hasMany('log-drain', {async:true}),
 
   // computed properties
-  allowPHI: Ember.computed.match('type', /production|platform|pilot/),
+  allowPHI: Ember.computed.match('type', /production/),
   appContainerCentsPerHour: function() {
     return this.get('allowPHI') ? 10 : 6;
   }.property('allowPHI')

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -7,6 +7,7 @@ export default DS.Model.extend({
   name: DS.attr('string'),
   username: DS.attr('string'),
   password: DS.attr('string'),
+  verified: DS.attr('boolean'),
 
   // used when changing a user's password. Set as an `attr` so that it
   // will be sent to the API

--- a/app/signup/route.js
+++ b/app/signup/route.js
@@ -40,7 +40,8 @@ export default Ember.Route.extend({
         return organization.save();
       }).then(function(){
         route.transitionTo('welcome.first-app');
-      }, function(){});
+      }, function(){
+      });
     }
 
   }

--- a/app/signup/template.hbs
+++ b/app/signup/template.hbs
@@ -29,6 +29,13 @@
           </div>
 
           <div class="form-group">
+            {{#if hasSubmitted}}
+              {{#if errors.organization.name}}
+                <div class="alert alert-warning">
+                  Organization name {{errors.organization.name}}
+                </div>
+              {{/if}}
+            {{/if}}
             {{input type="text"
               name="organization"
               value=organization.name

--- a/app/verify/route.js
+++ b/app/verify/route.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import { provisionDatabases } from '../models/database';
 
 export default Ember.Route.extend({
   model: function(params){
@@ -7,7 +8,15 @@ export default Ember.Route.extend({
       type: 'email'
     };
     var verification = this.store.createRecord('verification', options);
-    return verification.save();
+
+    return verification.save().then( () => {
+      let user = this.session.get('currentUser');
+
+      // this will update the 'verification' property
+      return user.reload();
+    }).then( (user) => {
+      return provisionDatabases(user, this.store);
+    });
   },
 
   afterModel: function() {

--- a/app/welcome/first-app/template.hbs
+++ b/app/welcome/first-app/template.hbs
@@ -11,6 +11,19 @@
         <div class="panel-body">
           <div class="form-group">
             <label class="block">
+              Stack Handle
+              <span class="label-helper">
+                Lowercase alphanumerics only
+              </span>
+            </label>
+            {{handle-input class="stack-handle form-control sanitize-handler"
+              placeholder="e.g., organization-prod"
+              name="stack-handle"
+              value=model.stackHandle
+              }}
+          </div>
+          <div class="form-group">
+            <label class="block">
               App Handle
               <span class="label-helper">
                 Lowercase alphanumerics only

--- a/app/welcome/payment-info/route.js
+++ b/app/welcome/payment-info/route.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import { createStripeToken } from '../../utils/stripe';
+import { provisionDatabases } from '../../models/database';
 
 export default Ember.Route.extend({
   model: function() {
@@ -37,7 +38,7 @@ export default Ember.Route.extend({
 
       Ember.RSVP.hash({
         stripeResponse: createStripeToken(options),
-        // TODO: the organization should probabaly be loaded
+        // TODO: the organization should probably be loaded
         // when the route is entered and the name displayed when
         // entering payment information
         organizations: store.find('organization')
@@ -92,6 +93,10 @@ export default Ember.Route.extend({
         }
 
         return Ember.RSVP.all(promises);
+      }).then(function(){
+        let currentUser = route.session.get('currentUser');
+
+        return provisionDatabases(currentUser, route.store);
       }).then(function(){
         route.transitionTo('index');
       }, function(error) {

--- a/app/welcome/route.js
+++ b/app/welcome/route.js
@@ -1,21 +1,16 @@
 import Ember from 'ember';
-import { read } from '../utils/storage';
-export var firstAppKey = '_aptible_firstAppData';
 
 export default Ember.Route.extend({
   model: function(){
-    var firstApp = read(firstAppKey);
-
-    if (firstApp) {
-      return firstApp;
-    } else {
+    return this.store.find('organization').then(function(organizations){
       return {
+        stackHandle: organizations.objectAt(0).get('name').dasherize(),
         appHandle: '',
         dbHandle: '',
         diskSize: 10,
         dbType: null
       };
-    }
+    });
   },
 
   beforeModel: function() {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.0.0",
-    "broccoli-sass": "^0.3.3",
+    "broccoli-sass": "^0.2.4",
     "ember-cli": "0.1.15",
     "ember-cli-6to5": "^3.0.0",
     "ember-cli-content-security-policy": "0.3.0",

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -55,6 +55,8 @@
     "stubOrganization",
     "stubApp",
     "stubDatabase",
+    "stubDatabases",
+    "stubUser",
     "expectPaginationElements",
     "clickNextPageLink",
     "clickPrevPageLink",

--- a/tests/acceptance/authentication-test.js
+++ b/tests/acceptance/authentication-test.js
@@ -245,5 +245,7 @@ test('Creating an account waits on a valid organization name', function() {
   click('button:contains(Sign Up)');
   andThen(function(){
     equal(currentPath(), 'signup', 'path does not change');
+    var error = find(':contains(minimum is 5 characters)');
+    ok(error.length, 'has error on the screen');
   });
 });

--- a/tests/acceptance/authentication-test.js
+++ b/tests/acceptance/authentication-test.js
@@ -184,7 +184,6 @@ test('visiting /signup when logged in redirects', function() {
 
 test('Creating an account directs to login', function() {
   stubStacks(); // For loading index
-  stubOrganization();
   stubOrganizations();
 
   var email = 'good@email.com';

--- a/tests/acceptance/welcome/first-app-test.js
+++ b/tests/acceptance/welcome/first-app-test.js
@@ -1,19 +1,14 @@
 import Ember from 'ember';
 import startApp from '../../helpers/start-app';
 
-import { read, write, remove } from '../../../utils/storage';
-import { firstAppKey } from  '../../../welcome/first-app/route';
-
 var application;
 
 module('Acceptance: WelcomeFirstApp', {
   setup: function() {
-    remove(firstAppKey);
     application = startApp();
   },
   teardown: function() {
     Ember.run(application, 'destroy');
-    remove(firstAppKey);
   }
 });
 
@@ -28,13 +23,12 @@ test('visiting /welcome/first-app when not logged in', function() {
 test('submitting a first app directs to subscriptions', function() {
   var appHandle = 'my-app';
 
+  stubOrganizations();
   signInAndVisit('/welcome/first-app');
 
   fillIn('input[name="app-handle"]', appHandle);
   click('button:contains(Get Started)');
   andThen(function() {
-    var stored = read(firstAppKey);
-    equal(stored.appHandle, appHandle, 'app handle is saved in localStorage');
     equal(currentPath(), 'welcome.payment-info', 'redirected to payment info');
   });
 });

--- a/tests/acceptance/welcome/payment-info-test.js
+++ b/tests/acceptance/welcome/payment-info-test.js
@@ -6,8 +6,8 @@ import { stubRequest } from "../../helpers/fake-server";
 var application;
 var oldCreateToken;
 
-function visitPaymentInfoWithApp(options){
-  signInAndVisit('/welcome/first-app');
+function visitPaymentInfoWithApp(options, userData){
+  signInAndVisit('/welcome/first-app', userData);
   if (options) {
     if (options.dbType) {
       click(`.${options.dbType} a`);
@@ -100,6 +100,7 @@ test('submitting valid payment info should be successful', function() {
   });
 
   stubOrganizations();
+  stubDatabases([]);
 
   mockStripe.card.createToken = function(options, fn) {
     equal(options.name, name, 'name is correct');
@@ -324,6 +325,92 @@ test('submitting valid payment info should be successful and create db', functio
     dbHandle: dbHandle,
     dbType: dbType
   });
+  fillIn('[name=name]', name);
+  fillIn('[name=number]', cardNumber);
+  fillIn('[name=cvc]', cvc);
+  fillIn('[name=exp-month]', expMonth);
+  fillIn('[name=exp-year]', expYear);
+  fillIn('[name=zip]', addressZip);
+  click('button:contains(Save)');
+
+  andThen(function() {
+    equal(currentPath(), 'stacks.index');
+  });
+});
+
+test('submitting valid payment info when user is verified should provision db', function() {
+  expect(12);
+  // This is to load apps.index
+  stubStacks();
+  stubOrganization();
+  var name = 'Bob Boberson';
+  var cardNumber = '4242424242424242';
+  var cvc = '123';
+  var expMonth = '03';
+  var expYear = '2019';
+  var addressZip = '11111';
+  var stripeToken = 'some-token';
+  var stackHandle = 'sprocket-co';
+  var dbHandle = 'my-db-1';
+  var dbType = 'redis';
+  let dbId = 'db-id';
+
+  stubRequest('post', '/organizations/1/subscriptions', function(request){
+    var params = JSON.parse(request.requestBody);
+    equal(params.stripe_token, stripeToken, 'stripe token is correct');
+    return this.success();
+  });
+
+  stubRequest('post', '/accounts', function(request){
+    var params = JSON.parse(request.requestBody);
+    return this.success({
+      id: params.handle,
+      handle: params.handle,
+      type: params.type
+    });
+  });
+
+  stubRequest('post', `/accounts/${stackHandle}-dev/databases`, function(request){
+    var params = JSON.parse(request.requestBody);
+    equal(params.handle, dbHandle, 'db handle is correct');
+    equal(params.type, dbType, 'db type is correct');
+    return this.success({
+      id: dbId
+    });
+  });
+
+  stubDatabases([{id:dbId}]);
+
+  stubRequest('post', `/databases/${dbId}/operations`, function(request){
+    ok(true, 'POSTs to create db provision operation');
+    let json = this.json(request);
+    equal(json.type, 'provision');
+
+    return this.success(201, {
+      id: 'op-id',
+      type: json.type
+    });
+  });
+
+  stubOrganizations();
+
+  mockStripe.card.createToken = function(options, fn) {
+    equal(options.name, name, 'name is correct');
+    equal(options.number, cardNumber, 'card number is correct');
+    equal(options.cvc, cvc, 'cvc is correct');
+    equal(options.exp_month, expMonth, 'exp month is correct');
+    equal(options.exp_year, expYear, 'exp year is correct');
+    equal(options.address_zip, addressZip, 'zip is correct');
+    setTimeout(function(){
+      fn(200, { id: stripeToken });
+    }, 2);
+  };
+
+  let userData = {id: 'user-id', verified: true};
+  visitPaymentInfoWithApp({
+    dbHandle: dbHandle,
+    dbType: dbType
+  }, userData);
   fillIn('[name=name]', name);
   fillIn('[name=number]', cardNumber);
   fillIn('[name=cvc]', cvc);

--- a/tests/acceptance/welcome/payment-info-test.js
+++ b/tests/acceptance/welcome/payment-info-test.js
@@ -6,6 +6,25 @@ import { stubRequest } from "../../helpers/fake-server";
 var application;
 var oldCreateToken;
 
+function visitPaymentInfoWithApp(options){
+  signInAndVisit('/welcome/first-app');
+  if (options) {
+    if (options.dbType) {
+      click(`.${options.dbType} a`);
+    }
+    for (var prop in options){
+      let dasherized = prop.dasherize();
+      if (dasherized === 'db-type') {
+        continue;
+      }
+      fillIn(`input[name="${dasherized}"]`, options[prop]);
+    }
+    click('button:contains(Get Started)');
+  } else {
+    click('a:contains(Skip this step)');
+  }
+}
+
 module('Acceptance: WelcomePaymentInfo', {
   setup: function() {
     application = startApp();
@@ -30,7 +49,7 @@ test('submitting empty payment info raises an error', function() {
 
   stubOrganizations();
 
-  signInAndVisit('/welcome/payment-info');
+  visitPaymentInfoWithApp();
   click('button:contains(Save)');
 
   andThen(function() {
@@ -41,7 +60,7 @@ test('submitting empty payment info raises an error', function() {
 });
 
 test('submitting valid payment info should be successful', function() {
-  expect(8);
+  expect(11);
   // This is to load apps.index
   stubStacks();
   stubOrganization();
@@ -52,10 +71,170 @@ test('submitting valid payment info should be successful', function() {
   var expYear = '2019';
   var addressZip = '11111';
   var stripeToken = 'some-token';
+  var stackHandle = 'sprocket-co';
+  var appHandle = 'my-app-1';
 
   stubRequest('post', '/organizations/1/subscriptions', function(request){
     var params = JSON.parse(request.requestBody);
     equal(params.stripe_token, stripeToken, 'stripe token is correct');
+    return this.success();
+  });
+
+  let stackAssertions = {};
+
+  stackAssertions[`${stackHandle}-dev`] = (params) => {
+    ok(true, 'stack handle is correct');
+    equal(params.type, 'development', 'stack type is correct');
+    stackAssertions[params.handle] = null;
+  };
+
+  stubRequest('post', '/accounts', function(request){
+    var params = JSON.parse(request.requestBody);
+    equal(params.organization_url, '/organizations/1', 'organization url is correct');
+    stackAssertions[params.handle](params);
+    return this.success({
+      id: stackHandle,
+      handle: stackHandle,
+      type: 'development'
+    });
+  });
+
+  stubOrganizations();
+
+  mockStripe.card.createToken = function(options, fn) {
+    equal(options.name, name, 'name is correct');
+    equal(options.number, cardNumber, 'card number is correct');
+    equal(options.cvc, cvc, 'cvc is correct');
+    equal(options.exp_month, expMonth, 'exp month is correct');
+    equal(options.exp_year, expYear, 'exp year is correct');
+    equal(options.address_zip, addressZip, 'zip is correct');
+    setTimeout(function(){
+      fn(200, { id: stripeToken });
+    }, 2);
+  };
+
+  visitPaymentInfoWithApp();
+  fillIn('[name=name]', name);
+  fillIn('[name=number]', cardNumber);
+  fillIn('[name=cvc]', cvc);
+  fillIn('[name=exp-month]', expMonth);
+  fillIn('[name=exp-year]', expYear);
+  fillIn('[name=zip]', addressZip);
+  click('button:contains(Save)');
+
+  andThen(function() {
+    equal(currentPath(), 'stacks.index');
+  });
+});
+
+test('submitting valid payment info for production plan should be successful', function() {
+  expect(14);
+  // This is to load apps.index
+  stubStacks();
+  stubOrganization();
+  var name = 'Bob Boberson';
+  var cardNumber = '4242424242424242';
+  var cvc = '123';
+  var expMonth = '03';
+  var expYear = '2019';
+  var addressZip = '11111';
+  var stripeToken = 'some-token';
+  var stackHandle = 'sprocket-co';
+  var appHandle = 'my-app-1';
+
+  stubRequest('post', '/organizations/1/subscriptions', function(request){
+    var params = JSON.parse(request.requestBody);
+    equal(params.stripe_token, stripeToken, 'stripe token is correct');
+    return this.success();
+  });
+
+  let stackAssertions = {};
+
+  stackAssertions[`${stackHandle}-dev`] = (params) => {
+    ok(true, 'stack handle is correct');
+    equal(params.type, 'development', 'stack type is correct');
+    stackAssertions[params.handle] = null;
+  };
+
+  stackAssertions[`${stackHandle}-prod`] = (params) => {
+    ok(true, 'stack handle is correct');
+    equal(params.type, 'production', 'stack type is correct');
+    stackAssertions[params.handle] = null;
+  };
+
+  stubRequest('post', '/accounts', function(request){
+    var params = JSON.parse(request.requestBody);
+    equal(params.organization_url, '/organizations/1', 'organization url is correct');
+    stackAssertions[params.handle](params);
+    return this.success({
+      id: stackHandle,
+      handle: stackHandle,
+      type: 'development'
+    });
+  });
+
+  stubOrganizations();
+
+  mockStripe.card.createToken = function(options, fn) {
+    equal(options.name, name, 'name is correct');
+    equal(options.number, cardNumber, 'card number is correct');
+    equal(options.cvc, cvc, 'cvc is correct');
+    equal(options.exp_month, expMonth, 'exp month is correct');
+    equal(options.exp_year, expYear, 'exp year is correct');
+    equal(options.address_zip, addressZip, 'zip is correct');
+    setTimeout(function(){
+      fn(200, { id: stripeToken });
+    }, 2);
+  };
+
+  visitPaymentInfoWithApp();
+  fillIn('[name=name]', name);
+  fillIn('[name=number]', cardNumber);
+  fillIn('[name=cvc]', cvc);
+  fillIn('[name=exp-month]', expMonth);
+  fillIn('[name=exp-year]', expYear);
+  fillIn('[name=zip]', addressZip);
+  fillIn('[name=plan]', 'production');
+  click('button:contains(Save)');
+
+  andThen(function() {
+    equal(currentPath(), 'stacks.index');
+  });
+});
+
+test('submitting valid payment info should be successful and create app', function() {
+  expect(9);
+  // This is to load apps.index
+  stubStacks();
+  stubOrganization();
+  var name = 'Bob Boberson';
+  var cardNumber = '4242424242424242';
+  var cvc = '123';
+  var expMonth = '03';
+  var expYear = '2019';
+  var addressZip = '11111';
+  var stripeToken = 'some-token';
+  var stackHandle = 'sprocket-co';
+  var appHandle = 'my-app-1';
+
+  stubRequest('post', '/organizations/1/subscriptions', function(request){
+    var params = JSON.parse(request.requestBody);
+    equal(params.stripe_token, stripeToken, 'stripe token is correct');
+    return this.success();
+  });
+
+  stubRequest('post', '/accounts', function(request){
+    var params = JSON.parse(request.requestBody);
+    return this.success({
+      id: params.handle,
+      handle: params.handle,
+      type: params.type
+    });
+  });
+
+  stubRequest('post', `/accounts/${stackHandle}-dev/apps`, function(request){
+    var params = JSON.parse(request.requestBody);
+    equal(params.handle, appHandle, 'app handle is correct');
     return this.success();
   });
 
@@ -73,7 +252,78 @@ test('submitting valid payment info should be successful', function() {
     }, 2);
   };
 
-  signInAndVisit('/welcome/payment-info');
+  visitPaymentInfoWithApp({
+    appHandle: appHandle
+  });
+  fillIn('[name=name]', name);
+  fillIn('[name=number]', cardNumber);
+  fillIn('[name=cvc]', cvc);
+  fillIn('[name=exp-month]', expMonth);
+  fillIn('[name=exp-year]', expYear);
+  fillIn('[name=zip]', addressZip);
+  click('button:contains(Save)');
+
+  andThen(function() {
+    equal(currentPath(), 'stacks.index');
+  });
+});
+
+test('submitting valid payment info should be successful and create db', function() {
+  expect(10);
+  // This is to load apps.index
+  stubStacks();
+  stubOrganization();
+  var name = 'Bob Boberson';
+  var cardNumber = '4242424242424242';
+  var cvc = '123';
+  var expMonth = '03';
+  var expYear = '2019';
+  var addressZip = '11111';
+  var stripeToken = 'some-token';
+  var stackHandle = 'sprocket-co';
+  var dbHandle = 'my-db-1';
+  var dbType = 'redis';
+
+  stubRequest('post', '/organizations/1/subscriptions', function(request){
+    var params = JSON.parse(request.requestBody);
+    equal(params.stripe_token, stripeToken, 'stripe token is correct');
+    return this.success();
+  });
+
+  stubRequest('post', '/accounts', function(request){
+    var params = JSON.parse(request.requestBody);
+    return this.success({
+      id: params.handle,
+      handle: params.handle,
+      type: params.type
+    });
+  });
+
+  stubRequest('post', `/accounts/${stackHandle}-dev/databases`, function(request){
+    var params = JSON.parse(request.requestBody);
+    equal(params.handle, dbHandle, 'db handle is correct');
+    equal(params.type, dbType, 'db type is correct');
+    return this.success();
+  });
+
+  stubOrganizations();
+
+  mockStripe.card.createToken = function(options, fn) {
+    equal(options.name, name, 'name is correct');
+    equal(options.number, cardNumber, 'card number is correct');
+    equal(options.cvc, cvc, 'cvc is correct');
+    equal(options.exp_month, expMonth, 'exp month is correct');
+    equal(options.exp_year, expYear, 'exp year is correct');
+    equal(options.address_zip, addressZip, 'zip is correct');
+    setTimeout(function(){
+      fn(200, { id: stripeToken });
+    }, 2);
+  };
+
+  visitPaymentInfoWithApp({
+    dbHandle: dbHandle,
+    dbType: dbType
+  });
   fillIn('[name=name]', name);
   fillIn('[name=number]', cardNumber);
   fillIn('[name=cvc]', cvc);

--- a/tests/helpers/aptible-helpers.js
+++ b/tests/helpers/aptible-helpers.js
@@ -3,25 +3,29 @@ import { locationHistory } from '../../utils/location';
 import { titleHistory } from '../../utils/title-route-extensions';
 import { stubRequest } from "./fake-server";
 
-Ember.Test.registerAsyncHelper('signIn', function(app){
+Ember.Test.registerAsyncHelper('signIn', function(app, userData){
+  let defaultUserData = {
+    id: 'user1',
+    name: 'stubbed user',
+    email: 'stubbed-user@gmail.com',
+    links: { sshKeys: '/users/user1/ssh_keys' }
+  };
+
+  userData = userData || defaultUserData;
+
   var session = app.__container__.lookup('torii:session');
   var sm = session.get('stateMachine');
 
   Ember.run(function(){
     var store = app.__container__.lookup('store:main');
-    var user = store.push('user', {
-      id: 'user1',
-      name: 'stubbed user',
-      email: 'stubbed-user@gmail.com',
-      links: { sshKeys: '/users/user1/ssh_keys' }
-    });
+    var user = store.push('user', userData);
     sm.transitionTo('authenticated');
     session.set('content.currentUser', user);
   });
 });
 
-Ember.Test.registerAsyncHelper('signInAndVisit', function(app, url){
-  signIn();
+Ember.Test.registerAsyncHelper('signInAndVisit', function(app, url, userData){
+  signIn(userData);
   visit(url);
 });
 
@@ -362,4 +366,21 @@ Ember.Test.registerHelper('expectInput', function(app, inputName, options) {
   } else {
     ok(false, `Found 0 of input "${inputName}"`);
   }
+});
+
+Ember.Test.registerHelper('stubDatabases', function(app, dbData){
+  stubRequest('get', '/databases', function(request){
+    return this.success({
+      _embedded: {
+        databases: dbData
+      }
+    });
+  });
+});
+
+Ember.Test.registerHelper('stubUser', function(app, userData={}){
+  stubRequest('get', '/users/:user_id', function(request){
+    userData.id = request.params.user_id;
+    return this.success(userData);
+  });
 });

--- a/tests/helpers/aptible-helpers.js
+++ b/tests/helpers/aptible-helpers.js
@@ -254,6 +254,7 @@ Ember.Test.registerHelper('stubOrganizations', function(app){
       _embedded: {
         organizations: [{
           _links: {
+            self: { href: '/organizations/1' }
           },
           id: 1,
           name: 'Sprocket Co',
@@ -269,6 +270,7 @@ Ember.Test.registerHelper('stubOrganization', function(app, id){
   stubRequest('get', '/organizations/'+id, function(request){
     return this.success({
       _links: {
+        self: { href: `/organizations/${id}` }
       },
       id: id,
       name: 'Sprocket Co',


### PR DESCRIPTION
With @bantic. This completes many of the edge cases around signup.

* Display validation errors for organization name
* Add stack handle to the app creation page (will need style, and a checkbox for phi-ready. Would need explanation that phi-ready will require a production plan on the next page)
* Create a dev stack, and if appropriate (a non-development plan) a prod stack
* Optionally apps and databases, after payment info is entered
* Provision databases after verification, or after subscription creation

TODO:

* [x] needs rebase

I would like to make provisioning databases (both upon validating an email and upon entering payment info when an email is valid) a separate PR.