### PR TITLE
Defer readiness when checking for `verification_code` param

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -2,8 +2,6 @@ import Ember from 'ember';
 import Resolver from 'ember/resolver';
 import loadInitializers from 'ember/load-initializers';
 import config from './config/environment';
-import { getUrlParameter } from './utils/url-parameters';
-import { replaceLocation } from './utils/location';
 import AuthenticatedRouteMixin from './mixins/routes/authenticated';
 
 // Calls reopen on route and router
@@ -16,13 +14,7 @@ Ember.Route.reopen(AuthenticatedRouteMixin);
 var App = Ember.Application.extend({
   modulePrefix: config.modulePrefix,
   podModulePrefix: config.podModulePrefix,
-  Resolver: Resolver,
-  ready: function(){
-    var verificationCode = getUrlParameter(window.location, 'verification_code');
-    if (verificationCode) {
-      replaceLocation('/verify/'+verificationCode);
-    }
-  }
+  Resolver: Resolver
 });
 
 loadInitializers(App, config.modulePrefix);

--- a/app/initializers/reroute-verification-code.js
+++ b/app/initializers/reroute-verification-code.js
@@ -1,0 +1,18 @@
+import { getUrlParameter } from '../utils/url-parameters';
+import { replaceLocation } from '../utils/location';
+
+export function initialize(container, application) {
+  application.deferReadiness();
+
+  var verificationCode = getUrlParameter(window.location, 'verification_code');
+  if (verificationCode) {
+    replaceLocation('/verify/'+verificationCode);
+  } else {
+    application.advanceReadiness();
+  }
+}
+
+export default {
+  name: 'reroute-verification-code',
+  initialize: initialize
+};


### PR DESCRIPTION
Only advance readiness if the code is not found.
This prevents a routing error when ember tries to recognize the
"/verify?verification_code" url.

fixes #115

@mixonic for you