### PR TITLE
Add support for accepting invites

### DIFF
--- a/app/claim/route.js
+++ b/app/claim/route.js
@@ -1,0 +1,31 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  unauthenticatedRedirect: 'signup',
+
+  model: function(params){
+    return {
+      verificationCode: params.verification_code,
+      invitationId: params.invitation_id,
+      type: 'invitation'
+    };
+  },
+
+  actions: {
+    claim: function(){
+      var options = this.currentModel;
+      var verification = this.store.createRecord('verification', options);
+
+      verification.save().then( () => {
+        this.replaceWith('index');
+      }, () => {
+        this.controllerFor('claim').set('error', `
+          There was an error accepting this invitation. Perhaps
+          the verification code has expired?
+        `);
+      });
+    }
+  }
+
+
+});

--- a/app/claim/template.hbs
+++ b/app/claim/template.hbs
@@ -1,0 +1,26 @@
+{{#login-box}}
+  <div class="row">
+    <div class="col-xs-6 col-xs-offset-3">
+      <div class="panel panel-subdued panel-focused">
+        <div class="panel-heading">
+          <h3>Invitation Acceptance</h3>
+        </div>
+        <div class="panel-body">
+          {{#if error}}
+            {{#bs-alert alert="danger"}}
+              {{error}}
+            {{/bs-alert}}
+          {{/if}}
+          <p>
+            You are currently signed in as {{session.currentUser.email}}.
+          </p>
+          <form>
+            <button class="btn btn-primary btn-block btn-lg" {{action "claim"}}>
+              Accept organization invitation
+            </button>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+{{/login-box}}

--- a/app/initializers/reroute-verification-code.js
+++ b/app/initializers/reroute-verification-code.js
@@ -5,8 +5,13 @@ export function initialize(container, application) {
   application.deferReadiness();
 
   var verificationCode = getUrlParameter(window.location, 'verification_code');
+  var invitationId = getUrlParameter(window.location, 'invitation_id');
   if (verificationCode) {
-    replaceLocation('/verify/'+verificationCode);
+    if (invitationId) {
+      replaceLocation(`/claim/${invitationId}/${verificationCode}`);
+    } else {
+      replaceLocation(`/verify/${verificationCode}`);
+    }
   } else {
     application.advanceReadiness();
   }

--- a/app/login/route.js
+++ b/app/login/route.js
@@ -28,12 +28,16 @@ export default Ember.Route.extend({
   actions: {
 
     login: function(authAttempt){
-      var route = this;
       var credentials = buildCredentials(authAttempt.email, authAttempt.password);
-      this.session.open('aptible', credentials).then(function(){
-        route.transitionTo('index');
-      }, function(e){
-        route.currentModel.set('error', e.message);
+      this.session.open('aptible', credentials).then(() => {
+        if (this.session.attemptedTransition) {
+          this.session.attemptedTransition.retry();
+          this.session.attemptedTransition = null;
+        } else {
+          this.transitionTo('index');
+        }
+      }, (e) => {
+        this.currentModel.set('error', e.message);
       });
     }
 

--- a/app/login/template.hbs
+++ b/app/login/template.hbs
@@ -2,10 +2,9 @@
   <div class="row">
     <div class="col-xs-6 col-xs-offset-3">
       {{#if model.error}}
-        <div class="alert alert-danger fade in">
-          <a class="close" data-dismiss="alert">×</a>
+        {{#bs-alert alert="danger"}}
           {{model.error}}
-        </div>
+        {{/bs-alert}}
       {{/if}}
       <div class="panel panel-subdued panel-focused">
         <div class="panel-heading">

--- a/app/mixins/routes/authenticated.js
+++ b/app/mixins/routes/authenticated.js
@@ -10,23 +10,25 @@ function loadUserRoles(route){
 
 export default Ember.Mixin.create({
   requireAuthentication: true, // default to requiring authentication
+  unauthenticatedRedirect: 'login',
 
-  beforeModel: function(){
+  beforeModel: function(transition){
     if (this.get('requireAuthentication')) {
-      return this._requireAuthentication();
+      return this._requireAuthentication(transition);
     } else {
       return this._checkLogin();
     }
   },
 
-  // redirect to 'login' if the user is not signed in
-  _requireAuthentication: function(){
+  // redirect if the user is not signed in
+  _requireAuthentication: function(transition){
     var route = this;
     if (!this.session.get('isAuthenticated')) {
+      this.session.attemptedTransition = transition;
       return this.session.fetch('aptible').then(function(){
         return loadUserRoles(route);
-      }).catch(function(){
-        route.transitionTo('login');
+      }).catch( () => {
+        route.transitionTo(Ember.get(this, 'unauthenticatedRedirect'));
       });
     } else {
       return loadUserRoles(route);

--- a/app/models/verification.js
+++ b/app/models/verification.js
@@ -2,5 +2,6 @@ import DS from 'ember-data';
 
 export default DS.Model.extend({
   verificationCode: DS.attr('string'),
+  invitationId: DS.attr('string'),
   type: DS.attr('string')
 });

--- a/app/router.js
+++ b/app/router.js
@@ -65,6 +65,10 @@ Router.map(function() {
     path: "verify/:verification_code"
   });
 
+  this.route("claim", {
+    path: "claim/:invitation_id/:verification_code"
+  });
+
   this.route("welcome", function() {
     this.route("first-app");
     this.route("payment-info");

--- a/app/signup/template.hbs
+++ b/app/signup/template.hbs
@@ -3,12 +3,11 @@
     <div class="col-xs-5 col-xs-offset-1">
 
       {{#unless model.isValid}}
-        <div class="alert alert-danger fade in">
-          <a class="close" data-dismiss="alert">×</a>
+        {{#bs-alert alert="danger"}}
           {{#each message in model.errors.messages}}
             <p>{{message}}</p>
           {{/each}}
-        </div>
+        {{/bs-alert}}
       {{/unless}}
 
       <div class="panel panel-default panel-subdued panel-focused">

--- a/app/welcome/payment-info/template.hbs
+++ b/app/welcome/payment-info/template.hbs
@@ -9,9 +9,9 @@
         <div class="panel-body">
           <form role="form">
             {{#if error}}
-              <div class="alert alert-danger fade in">
+              {{#bs-alert alert="danger"}}
                 <p>{{error.message}}</p>
-              </div>
+              {{/bs-alert}}
             {{/if}}
 
             <div class="form-group">

--- a/tests/acceptance/apps/create-test.js
+++ b/tests/acceptance/apps/create-test.js
@@ -86,7 +86,7 @@ test(`visit ${url} and create an app`, function(){
   let appHandle = 'abc-my-app-handle';
 
   stubRequest('post', '/accounts/my-stack-1/apps', function(request){
-    var json = JSON.parse(request.requestBody);
+    var json = this.json(request);
     equal(json.handle, appHandle, 'posts app handle');
 
     return this.success(201, {

--- a/tests/acceptance/authentication-test.js
+++ b/tests/acceptance/authentication-test.js
@@ -45,7 +45,7 @@ test('logging in with bad credentials', function() {
   var errorMessage = 'User not found: '+email;
 
   stubRequest('post', '/tokens', function(request){
-    var params = JSON.parse(request.requestBody);
+    var params = this.json(request);
     equal(params.username, email, 'correct email is passed');
     equal(params.password, password, 'correct password is passed');
     equal(params.grant_type, 'password', 'correct grant_type is passed');
@@ -78,7 +78,7 @@ test('logging in with correct credentials', function() {
   var userUrl = '/user-url';
 
   stubRequest('post', '/tokens', function(request){
-    var params = JSON.parse(request.requestBody);
+    var params = this.json(request);
     equal(params.username, email, 'correct email is passed');
     equal(params.password, password, 'correct password is passed');
     equal(params.grant_type, 'password', 'correct grant_type is passed');
@@ -192,7 +192,7 @@ test('Creating an account directs to login', function() {
   var organization = 'Great Co.';
 
   stubRequest('post', '/users', function(request){
-    var params = JSON.parse(request.requestBody);
+    var params = this.json(request);
     equal(params.email, email, 'correct email is passed');
     equal(params.password, password, 'correct password is passed');
     return this.success({
@@ -201,7 +201,7 @@ test('Creating an account directs to login', function() {
     });
   });
   stubRequest('post', '/tokens', function(request){
-    var params = JSON.parse(request.requestBody);
+    var params = this.json(request);
     equal(params.username, email, 'correct email is passed');
     equal(params.password, password, 'correct password is passed');
     return successfulTokenResponse(this, userUrl);
@@ -213,7 +213,7 @@ test('Creating an account directs to login', function() {
     });
   });
   stubRequest('post', '/organizations', function(request){
-    var params = JSON.parse(request.requestBody);
+    var params = this.json(request);
     equal(params.name, organization, 'correct organization is passed');
     return this.success({
       id: 'my-organization',

--- a/tests/acceptance/claim-test.js
+++ b/tests/acceptance/claim-test.js
@@ -1,0 +1,135 @@
+import Ember from 'ember';
+import startApp from '../helpers/start-app';
+import { stubRequest, jsonMimeType } from '../helpers/fake-server';
+
+var App;
+
+module('Acceptance: Claim', {
+  setup: function() {
+    App = startApp();
+  },
+  teardown: function() {
+    Ember.run(App, 'destroy');
+  }
+});
+
+test('visiting /claim/some-id/some-code requires authentication', function() {
+  visit('/claim/some-id/some-code');
+
+  andThen(function(){
+    equal(currentPath(), 'signup');
+  });
+});
+
+test('visiting /claim/some-id/some-code revisits after sign in', function() {
+  expect(4);
+
+  var userUrl = '/user-url';
+  stubRequest('post', '/tokens', function(request){
+    return this.success({
+      id: 'my-id',
+      access_token: 'my-token',
+      token_type: 'bearer',
+      expires_in: 2,
+      scope: 'manage',
+      type: 'token',
+      _links: {
+        user: {
+          href: userUrl
+        }
+      }
+    });
+  });
+  stubRequest('get', userUrl, function(){
+    return this.success({
+      id: 'some-id',
+      username: 'some-email'
+    });
+  });
+
+  stubRequest('post', '/verifications', function(request){
+    var params = JSON.parse(request.requestBody);
+    ok(true, 'verification posted');
+    return this.success({
+      id: 'this-id',
+      verification_code: params.verification_code
+    });
+  });
+  stubStacks(); // For loading index
+  stubOrganization();
+  stubOrganizations();
+
+  visit('/claim/some-id/some-code');
+  andThen(function(){
+    equal(currentPath(), 'signup');
+  });
+  click("a:contains(Sign in)");
+  click("button:contains(Log in)");
+  andThen(function(){
+    equal(currentPath(), 'claim');
+  });
+  click('button:contains(Accept organization invitation)');
+  andThen(function(){
+    equal(currentPath(), 'stacks.index');
+  });
+});
+
+test('visiting /claim/some-invitation/some-code creates verification', function() {
+  expect(3);
+  stubStacks(); // For loading index
+  stubOrganization();
+  stubOrganizations();
+  stubUser();
+  var verificationCode = 'some-code';
+  var invitationId = 'some-invitation';
+
+  stubRequest('post', '/verifications', function(request){
+    var params = JSON.parse(request.requestBody);
+    equal(params.verification_code, verificationCode, 'correct code is passed');
+    equal(params.invitation_id, invitationId, 'correct code is passed');
+    return this.success({
+      id: 'this-id',
+      verification_code: verificationCode
+    });
+  });
+
+  signInAndVisit(`/claim/${invitationId}/${verificationCode}`);
+  click('button:contains(Accept organization invitation)');
+  andThen(function(){
+    equal(currentPath(), 'stacks.index');
+  });
+});
+
+test('failed verification displays error', function() {
+  var verificationCode = 'some-code';
+  var invitationId = 'some-invitation';
+
+  stubRequest('post', '/verifications', function(request){
+    var params = JSON.parse(request.requestBody);
+    return [401, jsonMimeType, {}];
+  });
+
+  signInAndVisit(`/claim/${invitationId}/${verificationCode}`);
+  click('button:contains(Accept organization invitation)');
+  andThen(function(){
+    equal(currentPath(), 'claim');
+    ok(Ember.$(':contains(error accepting this invitation)').length, 'Failed verifications shows error');
+  });
+});
+
+test('failed verification displays error', function() {
+  var verificationCode = 'some-code';
+  var invitationId = 'some-invitation';
+
+  stubRequest('post', '/verifications', function(request){
+    var params = JSON.parse(request.requestBody);
+    return [401, jsonMimeType, {}];
+  });
+
+  signInAndVisit(`/claim/${invitationId}/${verificationCode}`);
+  click('button:contains(Accept organization invitation)');
+  andThen(function(){
+    equal(currentPath(), 'claim');
+    ok(Ember.$(':contains(error accepting this invitation)').length, 'Failed verifications shows error');
+  });
+});

--- a/tests/acceptance/claim-test.js
+++ b/tests/acceptance/claim-test.js
@@ -48,7 +48,7 @@ test('visiting /claim/some-id/some-code revisits after sign in', function() {
   });
 
   stubRequest('post', '/verifications', function(request){
-    var params = JSON.parse(request.requestBody);
+    var params = this.json(request);
     ok(true, 'verification posted');
     return this.success({
       id: 'this-id',
@@ -84,7 +84,7 @@ test('visiting /claim/some-invitation/some-code creates verification', function(
   var invitationId = 'some-invitation';
 
   stubRequest('post', '/verifications', function(request){
-    var params = JSON.parse(request.requestBody);
+    var params = this.json(request);
     equal(params.verification_code, verificationCode, 'correct code is passed');
     equal(params.invitation_id, invitationId, 'correct code is passed');
     return this.success({
@@ -105,7 +105,7 @@ test('failed verification displays error', function() {
   var invitationId = 'some-invitation';
 
   stubRequest('post', '/verifications', function(request){
-    var params = JSON.parse(request.requestBody);
+    var params = this.json(request);
     return [401, jsonMimeType, {}];
   });
 
@@ -122,7 +122,7 @@ test('failed verification displays error', function() {
   var invitationId = 'some-invitation';
 
   stubRequest('post', '/verifications', function(request){
-    var params = JSON.parse(request.requestBody);
+    var params = this.json(request);
     return [401, jsonMimeType, {}];
   });
 

--- a/tests/acceptance/databases/create-test.js
+++ b/tests/acceptance/databases/create-test.js
@@ -116,7 +116,7 @@ test(`visit ${url} and create`, function(){
 
   // create DB
   stubRequest('post', '/accounts/my-stack-1/databases', function(request){
-    var json = JSON.parse(request.requestBody);
+    var json = this.json(request);
     equal(json.handle, dbHandle, 'posts db handle');
     equal(json.type, 'redis', 'posts db type of redis');
 
@@ -128,7 +128,7 @@ test(`visit ${url} and create`, function(){
 
   // create 'provision' operation with disk size
   stubRequest('post', '/databases/' + dbId + '/operations', function(request){
-    var json = JSON.parse(request.requestBody);
+    var json = this.json(request);
     equal(json.type, 'provision', 'posts type of provision');
     equal(json.disk_size, diskSize, 'posts disk size');
 

--- a/tests/acceptance/settings/settings-account-test.js
+++ b/tests/acceptance/settings/settings-account-test.js
@@ -82,7 +82,7 @@ test('visit ' + settingsAccountUrl + ' allows changing password', function(){
       oldPassword = 'defghiljk';
 
   stubRequest('put', 'users/user1', function(request){
-    var user = JSON.parse(request.requestBody);
+    var user = this.json(request);
 
     equal(user.current_password, oldPassword);
     equal(user.password, newPassword);
@@ -120,7 +120,7 @@ test('visit ' + settingsAccountUrl + ' and change password with errors', functio
       oldPassword = 'defghiljk';
 
   stubRequest('put', 'users/user1', function(request){
-    var user = JSON.parse(request.requestBody);
+    var user = this.json(request);
 
     return this.error({
       code: 401,
@@ -184,7 +184,7 @@ test('visit ' + settingsAccountUrl + ' allows change email', function(){
   var currentPassword = 'alkjsdf';
 
   stubRequest('put', '/users/user1', function(request){
-    var user = JSON.parse(request.requestBody);
+    var user = this.json(request);
 
     equal(user.email, newEmail);
     equal(user.current_password, currentPassword);
@@ -215,7 +215,7 @@ test('visit ' + settingsAccountUrl + ' change email and errors', function(){
   var currentPassword = 'alkjsdf';
 
   stubRequest('put', '/users/user1', function(request){
-    var user = JSON.parse(request.requestBody);
+    var user = this.json(request);
 
     return this.error({
       code: 401,

--- a/tests/acceptance/settings/settings-profile-test.js
+++ b/tests/acceptance/settings/settings-profile-test.js
@@ -82,7 +82,7 @@ test('visit ' + settingsProfileUrl + ' allows updating name', function(){
 
   stubRequest('put', userApiUrl, function(request){
     ok(true, 'calls PUT ' + userApiUrl);
-    var user = JSON.parse(request.requestBody);
+    var user = this.json(request);
 
     equal(user.name, newName, 'updates with new name: ' + newName);
 

--- a/tests/acceptance/settings/settings-ssh-test.js
+++ b/tests/acceptance/settings/settings-ssh-test.js
@@ -114,7 +114,7 @@ test('visit ' + settingsSshUrl + ' allows adding a key', function(){
   var publicKey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC90B4...";
 
   stubRequest('post', '/users/user1/ssh_keys', function(request){
-    var json = JSON.parse(request.requestBody);
+    var json = this.json(request);
 
     equal(json.name, keyName);
     equal(json.ssh_public_key, publicKey);

--- a/tests/acceptance/verification-test.js
+++ b/tests/acceptance/verification-test.js
@@ -25,7 +25,7 @@ test('visiting /verify/some-code creates verification', function() {
   var verificationCode = 'some-code';
 
   stubRequest('post', '/verifications', function(request){
-    var params = JSON.parse(request.requestBody);
+    var params = this.json(request);
     equal(params.verification_code, verificationCode, 'correct code is passed');
     return this.success({
       id: 'this-id',
@@ -51,7 +51,7 @@ test('after verification, pending databases are provisioned', function(){
   stubDatabases(dbData);
 
   stubRequest('post', '/verifications', function(request){
-    var params = JSON.parse(request.requestBody);
+    var params = this.json(request);
     equal(params.verification_code, verificationCode, 'correct code is passed');
     return this.success({
       id: 'this-id',
@@ -82,7 +82,7 @@ test('failed verificaton directs to error page', function() {
   var verificationCode = 'some-code';
 
   stubRequest('post', '/verifications', function(request){
-    var params = JSON.parse(request.requestBody);
+    var params = this.json(request);
     equal(params.verification_code, verificationCode, 'correct code is passed');
     return [401, jsonMimeType, {}];
   });

--- a/tests/acceptance/welcome/payment-info-test.js
+++ b/tests/acceptance/welcome/payment-info-test.js
@@ -75,7 +75,7 @@ test('submitting valid payment info should be successful', function() {
   var appHandle = 'my-app-1';
 
   stubRequest('post', '/organizations/1/subscriptions', function(request){
-    var params = JSON.parse(request.requestBody);
+    var params = this.json(request);
     equal(params.stripe_token, stripeToken, 'stripe token is correct');
     return this.success();
   });
@@ -89,7 +89,7 @@ test('submitting valid payment info should be successful', function() {
   };
 
   stubRequest('post', '/accounts', function(request){
-    var params = JSON.parse(request.requestBody);
+    var params = this.json(request);
     equal(params.organization_url, '/organizations/1', 'organization url is correct');
     stackAssertions[params.handle](params);
     return this.success({
@@ -144,7 +144,7 @@ test('submitting valid payment info for production plan should be successful', f
   var appHandle = 'my-app-1';
 
   stubRequest('post', '/organizations/1/subscriptions', function(request){
-    var params = JSON.parse(request.requestBody);
+    var params = this.json(request);
     equal(params.stripe_token, stripeToken, 'stripe token is correct');
     return this.success();
   });
@@ -164,7 +164,7 @@ test('submitting valid payment info for production plan should be successful', f
   };
 
   stubRequest('post', '/accounts', function(request){
-    var params = JSON.parse(request.requestBody);
+    var params = this.json(request);
     equal(params.organization_url, '/organizations/1', 'organization url is correct');
     stackAssertions[params.handle](params);
     return this.success({
@@ -219,13 +219,13 @@ test('submitting valid payment info should be successful and create app', functi
   var appHandle = 'my-app-1';
 
   stubRequest('post', '/organizations/1/subscriptions', function(request){
-    var params = JSON.parse(request.requestBody);
+    var params = this.json(request);
     equal(params.stripe_token, stripeToken, 'stripe token is correct');
     return this.success();
   });
 
   stubRequest('post', '/accounts', function(request){
-    var params = JSON.parse(request.requestBody);
+    var params = this.json(request);
     return this.success({
       id: params.handle,
       handle: params.handle,
@@ -234,7 +234,7 @@ test('submitting valid payment info should be successful and create app', functi
   });
 
   stubRequest('post', `/accounts/${stackHandle}-dev/apps`, function(request){
-    var params = JSON.parse(request.requestBody);
+    var params = this.json(request);
     equal(params.handle, appHandle, 'app handle is correct');
     return this.success();
   });
@@ -286,13 +286,13 @@ test('submitting valid payment info should be successful and create db', functio
   var dbType = 'redis';
 
   stubRequest('post', '/organizations/1/subscriptions', function(request){
-    var params = JSON.parse(request.requestBody);
+    var params = this.json(request);
     equal(params.stripe_token, stripeToken, 'stripe token is correct');
     return this.success();
   });
 
   stubRequest('post', '/accounts', function(request){
-    var params = JSON.parse(request.requestBody);
+    var params = this.json(request);
     return this.success({
       id: params.handle,
       handle: params.handle,
@@ -301,7 +301,7 @@ test('submitting valid payment info should be successful and create db', functio
   });
 
   stubRequest('post', `/accounts/${stackHandle}-dev/databases`, function(request){
-    var params = JSON.parse(request.requestBody);
+    var params = this.json(request);
     equal(params.handle, dbHandle, 'db handle is correct');
     equal(params.type, dbType, 'db type is correct');
     return this.success();
@@ -356,13 +356,13 @@ test('submitting valid payment info when user is verified should provision db', 
   let dbId = 'db-id';
 
   stubRequest('post', '/organizations/1/subscriptions', function(request){
-    var params = JSON.parse(request.requestBody);
+    var params = this.json(request);
     equal(params.stripe_token, stripeToken, 'stripe token is correct');
     return this.success();
   });
 
   stubRequest('post', '/accounts', function(request){
-    var params = JSON.parse(request.requestBody);
+    var params = this.json(request);
     return this.success({
       id: params.handle,
       handle: params.handle,
@@ -371,7 +371,7 @@ test('submitting valid payment info when user is verified should provision db', 
   });
 
   stubRequest('post', `/accounts/${stackHandle}-dev/databases`, function(request){
-    var params = JSON.parse(request.requestBody);
+    var params = this.json(request);
     equal(params.handle, dbHandle, 'db handle is correct');
     equal(params.type, dbType, 'db type is correct');
     return this.success({

--- a/tests/unit/claim/route-test.js
+++ b/tests/unit/claim/route-test.js
@@ -1,0 +1,14 @@
+import {
+  moduleFor,
+  test
+} from 'ember-qunit';
+
+moduleFor('route:claim', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+test('it exists', function(assert) {
+  var route = this.subject();
+  assert.ok(route);
+});

--- a/tests/unit/models/subscription-test.js
+++ b/tests/unit/models/subscription-test.js
@@ -16,7 +16,7 @@ test('data is posted upon save', function() {
   var organizationId = 'org-1';
 
   stubRequest('post', '/organizations/org-1/subscriptions', function(request){
-    var params = JSON.parse(request.requestBody);
+    var params = this.json(request);
     equal(params.stripe_token, stripeToken, 'stripe token is correct');
     equal(params.plan, plan, 'plan is correct');
     equal(params.organization_id, organizationId, 'org id is correct');


### PR DESCRIPTION
@bantic for you to review and merge.

Invites can be accepted by signed in users. Users who are not signed in will be redirected to login/signup and redirected back once they
complete the process.

The invite page itself renders, then starts the AJAX request to claim the invitation automatically.

URLs such as:

* `http://localhost:4200/claim?verification_code=abc&invitation_id=59ef9caa-292c-42b0-b90f-000b7432b743`
* `http://localhost:4200/claim/59ef9caa-292c-42b0-b90f-000b7432b743/abc-verification-code`

Are supported. This is compatible with emails out there in the wild.

This PR introduces general support for redirecting to a path after signing in. See the `attemptedTransition` property.