### PR TITLE
Pass initial diskSize to databases, use in provisioning

### DIFF
--- a/app/models/database.js
+++ b/app/models/database.js
@@ -7,6 +7,7 @@ export default DS.Model.extend({
   connectionUrl: DS.attr('string'),
   type: DS.attr('string'), // postgresql, redis, etc.
   createdAt: DS.attr('iso-8601-timestamp'),
+  initialDiskSize: DS.attr('number'),
 
   // relationships
   stack: DS.belongsTo('stack', {async: true}),
@@ -21,7 +22,7 @@ export function provisionDatabases(user, store){
     let promises = databases.map(function(database){
       let op = store.createRecord('operation', {
         type: 'provision',
-        diskSize: '10', // FIXME
+        diskSize: database.get('initialDiskSize') || '10',
         database: database
       });
       return op.save();

--- a/app/welcome/first-app/route.js
+++ b/app/welcome/first-app/route.js
@@ -1,12 +1,12 @@
 import Ember from 'ember';
-import { write } from '../../utils/storage';
 export var firstAppKey = '_aptible_firstAppData';
 
 export default Ember.Route.extend({
   actions: {
 
-    create: function(model){
-      write(firstAppKey, model);
+    create: function(){
+      // model data is already stored on the parent
+      // route (welcome). Just move forward.
       this.transitionTo('welcome.payment-info');
     },
 
@@ -15,7 +15,7 @@ export default Ember.Route.extend({
     },
 
     setDiskSize: function(diskSize){
-      Ember.set(this.currentModel, 'diskSize', diskSize);
+      Ember.set(this.currentModel, 'initialDiskSize', diskSize);
     }
 
   }

--- a/app/welcome/first-app/template.hbs
+++ b/app/welcome/first-app/template.hbs
@@ -66,7 +66,7 @@
               <label>Disk Size</label>
               <div class="slider-input-wrapper disk-size-slider">
                 <div class="container-count">
-                  {{model.diskSize}} GB
+                  {{model.initialDiskSize}} GB
                 </div>
                 <div class="slider-wrapper">
                   {{no-ui-slider didSlide="setDiskSize"

--- a/app/welcome/payment-info/route.js
+++ b/app/welcome/payment-info/route.js
@@ -87,6 +87,7 @@ export default Ember.Route.extend({
           var db = store.createRecord('database', {
             handle: welcomeModel.dbHandle,
             type: welcomeModel.dbType,
+            initialDiskSize: welcomeModel.initialDiskSize,
             stack: stack
           });
           promises.push(db.save());

--- a/app/welcome/route.js
+++ b/app/welcome/route.js
@@ -7,7 +7,7 @@ export default Ember.Route.extend({
         stackHandle: organizations.objectAt(0).get('name').dasherize(),
         appHandle: '',
         dbHandle: '',
-        diskSize: 10,
+        initialDiskSize: 10,
         dbType: null
       };
     });

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -72,7 +72,8 @@
     "findButton",
     "expectButton",
     "expectNoButton",
-    "clickButton"
+    "clickButton",
+    "triggerSlider"
   ],
   "node": false,
   "browser": false,

--- a/tests/acceptance/verification-test.js
+++ b/tests/acceptance/verification-test.js
@@ -41,14 +41,15 @@ test('visiting /verify/some-code creates verification', function() {
 });
 
 test('after verification, pending databases are provisioned', function(){
-  expect(4);
+  expect(5);
   stubStacks(); // For loading index
   stubOrganization();
   stubOrganizations();
   var verificationCode = 'some-code';
   let dbId = 'db-id';
+  let diskSize = '10';
 
-  let dbData = [{id: dbId}];
+  let dbData = [{id: dbId, initialDiskSize: diskSize}];
   stubDatabases(dbData);
 
   stubRequest('post', '/verifications', function(request){
@@ -66,6 +67,7 @@ test('after verification, pending databases are provisioned', function(){
     ok(true, 'posts to create db provision op');
     let json = this.json(request);
     equal(json.type, 'provision');
+    equal(json.disk_size, diskSize);
 
     return this.success({
       id: 'op-id',

--- a/tests/helpers/aptible-helpers.js
+++ b/tests/helpers/aptible-helpers.js
@@ -447,3 +447,7 @@ Ember.Test.registerHelper('stubUser', function(app, userData={}){
     return this.success(userData);
   });
 });
+
+Ember.Test.registerAsyncHelper('triggerSlider', function(app, selector, argument){
+  Ember.$(selector).trigger('slide', argument);
+});


### PR DESCRIPTION
@bantic for you to review/merge. Closes https://github.com/aptible/diesel.aptible.com/issues/117

The `initialDiskSize` attribute is part of the first-app page. It is saved with a database upon creation, and then used for `diskSize` when provisioning occurs.

The normal database creation path (non-ftux) already handles setting the `diskSize` correctly (on the operation).