### PR TITLE
Focus first form input for apps/new, dbs/new, vhosts/new, logs/new

### DIFF
--- a/app/app/vhosts/new/template.hbs
+++ b/app/app/vhosts/new/template.hbs
@@ -17,10 +17,11 @@
 
           <div class="form-group">
             <label>Service</label>
-            {{view "select" content=services
+            {{view "autofocusable-select" content=services
                             selection=vhostService
                             name="service"
                             optionLabelPath="content.handle"
+                            autofocus=true
                             class="form-control"}}
           </div>
 

--- a/app/apps/new/template.hbs
+++ b/app/apps/new/template.hbs
@@ -20,7 +20,7 @@
               App handle
               <span class="label-helper">Lowercase alphanumerics, periods, and dashes only</span>
             </label>
-            {{handle-input class="form-control" value=model.handle name='handle'}}
+            {{handle-input class="form-control" value=model.handle name='handle' autofocus=true}}
           </div>
         </form>
 

--- a/app/components/handle-input/component.js
+++ b/app/components/handle-input/component.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import Autofocusable from 'diesel/mixins/views/autofocusable';
 
 export var maxChars = 64;
 
@@ -23,7 +24,7 @@ function sanitizeInput(input){
          replace(nonAlphaNumerics, '');
 }
 
-export default Ember.TextField.extend({
+export default Ember.TextField.extend(Autofocusable, {
   _sanitizedValue: null,
   value: Ember.computed(function(key, value){
     if (arguments.length > 1) {

--- a/app/databases/new/template.hbs
+++ b/app/databases/new/template.hbs
@@ -27,6 +27,7 @@
             {{handle-input class="database-name form-control sanitize-handler"
                     placeholder="e.g., postgresql-prod"
                     name="handle"
+                    autofocus=true
                     value=model.handle}}
           </div>
 

--- a/app/mixins/views/autofocusable.js
+++ b/app/mixins/views/autofocusable.js
@@ -1,0 +1,9 @@
+import Ember from 'ember';
+
+export default Ember.Mixin.create({
+  fixAutofocus: function(){
+    if (this.get('autofocus')) {
+      this.$().focus();
+    }
+  }.on('didInsertElement')
+});

--- a/app/stack/log-drains/new/template.hbs
+++ b/app/stack/log-drains/new/template.hbs
@@ -16,7 +16,7 @@
 
           <div class="form-group">
             <label class="block" for="drain-handle">Handle</label>
-            {{handle-input class="form-control" value=model.handle name='handle'}}
+            {{handle-input class="form-control" value=model.handle name='handle' autofocus=true}}
           </div>
           <div class="form-group">
             <label class="block" for="drain-type">Type</label>

--- a/app/views/autofocusable-select.js
+++ b/app/views/autofocusable-select.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+import Autofocusable from 'diesel/mixins/views/autofocusable';
+
+export default Ember.Select.extend(Autofocusable);

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -66,6 +66,7 @@
     "expectNoLink",
     "findInput",
     "expectInput",
+    "expectFocusedInput",
     "fillInput",
     "findButton",
     "expectButton",

--- a/tests/acceptance/apps/create-test.js
+++ b/tests/acceptance/apps/create-test.js
@@ -46,7 +46,7 @@ test(`visiting /stacks/:stack_id/apps without any apps redirects to ${url}`, fun
 });
 
 test(`visit ${url} shows basic info`, function(){
-  expect(5);
+  expect(6);
 
   signInAndVisit(url);
   andThen(function(){
@@ -55,6 +55,7 @@ test(`visit ${url} shows basic info`, function(){
     expectButton('Save App');
     expectButton('Cancel');
     titleUpdatedTo(`Create an App - ${stackHandle}`);
+    expectFocusedInput('handle');
   });
 });
 

--- a/tests/acceptance/apps/vhost-new-test.js
+++ b/tests/acceptance/apps/vhost-new-test.js
@@ -2,13 +2,13 @@ import Ember from 'ember';
 import startApp from '../../helpers/start-app';
 import { stubRequest } from '../../helpers/fake-server';
 
-var App;
+let App;
 
-var appId = '1';
-var appUrl = '/apps/' + appId;
-var appVhostsUrl = '/apps/' + appId + '/vhosts';
-var appVhostsApiUrl = '/apps/' + appId + '/vhosts';
-var appVhostsNewUrl = '/apps/' + appId + '/vhosts/new';
+let appId = '1';
+let appUrl = '/apps/' + appId;
+let appVhostsUrl = '/apps/' + appId + '/vhosts';
+let appVhostsApiUrl = '/apps/' + appId + '/vhosts';
+let appVhostsNewUrl = '/apps/' + appId + '/vhosts/new';
 
 var formInputNames = ['service', 'virtual-domain', 'certificate', 'private-key'];
 
@@ -69,6 +69,7 @@ test(`visit ${appVhostsNewUrl} shows creation form`, function(){
     ok(find('.panel-heading:contains(Create a new VHost)').length,
        'has header');
     expectInput('service', {input:'select'});
+    expectFocusedInput('service', {input:'select'});
     expectInput('virtual-domain');
     expectInput('certificate', {input:'textarea'});
     expectInput('private-key', {input:'textarea'});

--- a/tests/acceptance/databases/create-test.js
+++ b/tests/acceptance/databases/create-test.js
@@ -65,6 +65,7 @@ test(`visit ${url} shows basic info`, function(){
     equal(currentPath(), 'stack.databases.new');
 
     expectInput('handle');
+    expectFocusedInput('handle');
     expectButton('Save Database');
     expectButton('Cancel');
 

--- a/tests/acceptance/log-drains/basic-test.js
+++ b/tests/acceptance/log-drains/basic-test.js
@@ -60,8 +60,7 @@ test(`visit ${url} shows basic info`, function(assert){
   andThen(function(){
     equal(currentPath(), 'stack.log-drains.index');
 
-    ok( find('.btn:contains(Add Log)').length,
-        'button to add log');
+    expectButton('Add Log');
 
     let logDrainEls = find('.log-drain');
     equal( logDrainEls.length, logDrains.length );
@@ -92,7 +91,7 @@ test(`visit ${url} with log drains and click add log shows form`, function(asser
   signInAndVisit(url);
 
   andThen(function(){
-    click('.btn:contains(Add Log)');
+    clickButton('Add Log');
   });
 
   andThen(function(){
@@ -107,6 +106,7 @@ test(`visit ${url} with log drains and click add log shows form`, function(asser
     expectInput('drain-port', {context});
     expectInput('handle', {context});
     expectInput('drain-type', {context});
+    expectFocusedInput('handle', {context});
 
     expectButton('Save Log Drain');
     expectButton('Cancel');

--- a/tests/helpers/aptible-helpers.js
+++ b/tests/helpers/aptible-helpers.js
@@ -409,6 +409,23 @@ Ember.Test.registerHelper('expectInput', function(app, inputName, options) {
   }
 });
 
+Ember.Test.registerAsyncHelper('expectFocusedInput', function(app, inputName, options) {
+  // run.later gives DOM a chance to catch up, so that `autofocus` takes effect, e.g.
+  return Ember.run.later(null, () => {
+    let input = findInput(inputName, options);
+    if (!input.length) {
+      ok(false, `Found ${input.length} of input "${inputName}"`);
+    } else {
+      let el = input.get(0);
+      if (document.activeElement === el) {
+        ok(true, `Found focused input "${inputName}"`);
+      } else {
+        ok(false, `Expect input "${inputName}" to be focused`);
+      }
+    }
+  }, 0);
+});
+
 Ember.Test.registerAsyncHelper('fillInput', function(app, inputName, value, inputOptions){
   let input = findInput(inputName, inputOptions);
   if (!input.length) {

--- a/tests/unit/components/handle-input/component-test.js
+++ b/tests/unit/components/handle-input/component-test.js
@@ -139,3 +139,11 @@ test(`setting more than ${maxChars} chars truncates to ${maxChars}`, function(as
   assert.equal(input.val(), text);
   assert.equal(component.get('value'), text);
 });
+
+test(`autofocusable`, function(assert){
+  var component = this.subject({autofocus:true});
+
+  var $el = this.render();
+  var el = $el[0];
+  assert.equal(document.activeElement, el, 'input is focused');
+});


### PR DESCRIPTION
  * add autofocusable-select view
  * add Autofocusable mixin to reclaim focus when input is inserted
  * mix Autofocusable into autofocusable-select and handle-input
  * add `expectFocusedInput` test helper

fixes #146 

@mixonic  for you, cc @sandersonet 

Learned some interesting things about the html `autofocus` boolean attr while doing this. Namely that it doesn't work as well as it should, esp on FF and Chrome. When an input is added to the DOM via JavaScript it doesn't always get focused even with the autofocus attribute set. That's the reason for the `Autofocusable` mixin.

Example [jsbin demonstrating this with ember](http://jsbin.com/tasiqo) and [jsbin demonstrating without ember](http://jsbin.com/hewage#). Doing it this way is somewhat hacky but I think a good balance between a more explicit solution (e.g., a view specifically for each route that finds and focuses the input) and more hacking to fix the buggy browser autofocus. If this were a mission-critical feature rather than an enhancement I would suggest a bit more work making it bulletproof.

cc @sandersonet 