### PR TITLE
Hide cancel button on apps/new and dbs/new when stack has no apps or dbs

### DIFF
--- a/app/apps/new/controller.js
+++ b/app/apps/new/controller.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  needs: ['stack'],
+  persistedApps: Ember.computed.alias('controllers.stack.persistedApps'),
+  showCancelButton: Ember.computed.gt('persistedApps.length', 0)
+});

--- a/app/apps/new/template.hbs
+++ b/app/apps/new/template.hbs
@@ -30,9 +30,11 @@
 </div>
 
 <div class="resource-actions">
-  <button class="btn btn-default" {{action 'cancel'}}>
-    Cancel
-  </button>
+  {{#if showCancelButton}}
+    <button class="btn btn-default" {{action 'cancel'}}>
+      Cancel
+    </button>
+  {{/if}}
   <button class="btn btn-primary" {{action 'create'}}>
     Save App
   </button>

--- a/app/databases/new/controller.js
+++ b/app/databases/new/controller.js
@@ -1,6 +1,10 @@
 import Ember from 'ember';
 
 export default Ember.Controller.extend({
+  needs: ['stack'],
+  persistedDatabases: Ember.computed.alias('controllers.stack.persistedDatabases'),
+  showCancelButton: Ember.computed.gt('persistedDatabases.length', 0),
+
   diskSize: 10,
 
   actions: {

--- a/app/databases/new/template.hbs
+++ b/app/databases/new/template.hbs
@@ -68,9 +68,11 @@
 </div>
 
 <div class="resource-actions">
-  <button {{action 'cancel'}} class="btn btn-default" type='button'>
-    Cancel
-  </button>
+  {{#if showCancelButton}}
+    <button {{action 'cancel'}} class="btn btn-default" type='button'>
+      Cancel
+    </button>
+  {{/if}}
 
   <button {{action 'create'}} class="btn btn-primary" type='submit'>
     Save Database

--- a/tests/acceptance/apps/create-test.js
+++ b/tests/acceptance/apps/create-test.js
@@ -6,16 +6,17 @@ var App;
 let url = '/stacks/my-stack-1/apps/new';
 let appIndexUrl = '/stacks/my-stack-1/apps';
 let stackId = 'my-stack-1';
+let stackHandle = 'my-stack-handle';
 
 module('Acceptance: App Create', {
   setup: function() {
     App = startApp();
     stubStacks({ includeApps: true });
     stubStack({
-      id: 'my-stack-1',
-      handle: 'my-stack-1',
+      id: stackId,
+      handle: stackHandle,
       _links: {
-        apps: { href: '/accounts/my-stack-1/apps' },
+        apps: { href: `/accounts/${stackId}/apps` },
         organization: { href: '/organizations/1' }
       }
     });
@@ -34,10 +35,18 @@ test(`${url} requires authentication`, function(){
   expectRequiresAuthentication(url);
 });
 
+test(`visiting /stacks/:stack_id/apps without any apps redirects to ${url}`, function() {
+  stubStack({ id: stackId });
+  stubOrganization();
+  signInAndVisit(`/stacks/${stackId}/apps`);
+
+  andThen(function() {
+    equal(currentPath(), 'stack.apps.new');
+  });
+});
+
 test(`visit ${url} shows basic info`, function(){
   expect(5);
-  let stackHandle = 'my-new-stack';
-  stubStack({id:stackId, handle: stackHandle});
 
   signInAndVisit(url);
   andThen(function(){
@@ -63,6 +72,17 @@ test(`visit ${url} and cancel`, function(){
 
     ok( !findApp(appHandle).length,
         'does not show app');
+  });
+});
+
+test(`visit ${url} without apps show no cancel button`, function(){
+  stubStack({id: stackId}); // stubs a stack with no apps
+  signInAndVisit(url);
+
+  andThen(function(){
+    equal(currentPath(), 'stack.apps.new');
+    let button = findButton('Cancel');
+    ok(!button.length, 'Cancel button is not present');
   });
 });
 

--- a/tests/acceptance/databases/create-test.js
+++ b/tests/acceptance/databases/create-test.js
@@ -6,16 +6,17 @@ var App;
 let url = '/stacks/my-stack-1/databases/new';
 let dbIndexUrl = '/stacks/my-stack-1/databases';
 let stackId = 'my-stack-1';
+let stackHandle = 'my-stack-handle';
 
 module('Acceptance: Database Create', {
   setup: function() {
     App = startApp();
     stubStacks({ includeDatabases: true });
     stubStack({
-      id: 'my-stack-1',
-      handle: 'my-stack-1',
+      id: stackId,
+      handle: stackHandle,
       _links: {
-        databases: { href: '/accounts/my-stack-1/databases' },
+        databases: { href: `/accounts/${stackId}/databases` },
         organization: { href: '/organizations/1' }
       }
     });
@@ -44,11 +45,20 @@ test(`visiting /stacks/:stack_id/databases without any databases redirects to ${
   });
 });
 
-test(`visit ${url} shows basic info`, function(){
-  let stackHandle = 'my-cool-handle';
-  stubStack({id: stackId, handle: stackHandle});
+test(`visit ${url} when stack has no databases does not show cancel`, function(){
+  stubStack({ id: stackId }); // stubs a stack with no databases
   stubOrganization();
+  signInAndVisit(url);
 
+  andThen(function() {
+    equal(currentPath(), 'stack.databases.new');
+    let button = findButton('Cancel');
+    ok(!button.length, 'has no cancel button');
+  });
+});
+
+test(`visit ${url} shows basic info`, function(){
+  stubOrganization();
   signInAndVisit(url);
 
   andThen(function(){


### PR DESCRIPTION
Default behavior of the cancel button is to go to the index, but default
behavior of the index when no apps/dbs is to redirect to /new, so the
user thinks the cancel button is doing nothing.

fixes #165