### PR TITLE
Disable login button while user is logging in

### DIFF
--- a/app/login/controller.js
+++ b/app/login/controller.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  isLoggingIn: false
+});

--- a/app/login/route.js
+++ b/app/login/route.js
@@ -4,7 +4,7 @@ import DisallowAuthenticated from "../mixins/routes/disallow-authenticated";
 export function buildCredentials(email, password) {
   return {
     username: email,
-    password: password,
+    password,
     grant_type: 'password',
     scope: 'manage'
   };
@@ -29,6 +29,9 @@ export default Ember.Route.extend(DisallowAuthenticated, {
 
     login: function(authAttempt){
       var credentials = buildCredentials(authAttempt.email, authAttempt.password);
+
+      this.controller.set('isLoggingIn', true);
+
       this.session.open('aptible', credentials).then(() => {
         if (this.session.attemptedTransition) {
           this.session.attemptedTransition.retry();
@@ -38,6 +41,8 @@ export default Ember.Route.extend(DisallowAuthenticated, {
         }
       }, (e) => {
         this.currentModel.set('error', e.message);
+      }).finally( () => {
+        this.controller.set('isLoggingIn', false);
       });
     }
 

--- a/app/login/template.hbs
+++ b/app/login/template.hbs
@@ -30,8 +30,15 @@
                 class="form-control"
                 placeholder="Password"}}
             </div>
-            <button class="btn btn-primary btn-block btn-lg" {{action "login" model}}>
-              Log in
+            <button
+              disabled={{isLoggingIn}}
+              class="btn btn-primary btn-block btn-lg"
+              {{action "login" model}}>
+              {{#if isLoggingIn}}
+                Logging you in...
+              {{else}}
+                Log in
+              {{/if}}
             </button>
           </form>
 


### PR DESCRIPTION
This makes the login button disabled (and its message changes to "Logging you in...")  while the user is being logged in.
A UI enhancement and prevents this error that can occur if torii attempts to log a user in while they are already logging in (double-clicking the login button will cause this, for example)

![login](https://cloud.githubusercontent.com/assets/2023/6712458/087b40ca-cd63-11e4-80e9-1b49d4f4947e.gif)

(edited to fix gif above)

cc @sandersonet 
I'll merge this in when the tests pass.