### PR TITLE
Clear errors on password reset. Fixes #170

### DIFF
--- a/app/password/reset/route.js
+++ b/app/password/reset/route.js
@@ -15,6 +15,9 @@ export default Ember.Route.extend(DisallowAuthenticated, {
           There was an error resetting your password.
         `);
       });
+    },
+    willTransition() {
+      this.controllerFor('password/reset').set('error', null);
     }
   }
 });

--- a/tests/acceptance/password/reset-test.js
+++ b/tests/acceptance/password/reset-test.js
@@ -48,8 +48,8 @@ test('visiting /password/reset and submitting an email creates password reset', 
   });
 });
 
-test('visiting /password/reset and submitting an email handles error', function() {
-  expect(2);
+test('visiting /password/reset and submitting an email handles error and resets upon departure', function() {
+  expect(5);
   var email = 'myEmail@email.com';
 
   stubRequest('post', '/password/resets/new', function(request){
@@ -61,6 +61,13 @@ test('visiting /password/reset and submitting an email handles error', function(
   click('button:contains(Email me reset instructions)');
   andThen(function(){
     ok(find(':contains(There was an error resetting)'), 'error is on the page');
+    equal(currentPath(), 'password.reset');
+  });
+  visit('/login');
+  visit('/password/reset');
+  andThen(function(){
+    ok(find(':contains(There was an error resetting)').length === 0, 'error is not on the page');
+    ok(find('[type=email]'), 'email prompt is on the page');
     equal(currentPath(), 'password.reset');
   });
 });


### PR DESCRIPTION
Errors were persisting on the password reset page. This ensure they are cleared when the user navigates away.