### PR TITLE
ensure that error messages for email/password change are cleared

### DIFF
--- a/app/password/reset/controller.js
+++ b/app/password/reset/controller.js
@@ -12,14 +12,16 @@ export default Ember.Controller.extend(EmberValidations.Mixin, {
 
   actions: {
 
-    reset: function(model){
-      var hasSubmitted = this.get('hasSubmitted');
+    reset(model) {
+      let hasSubmitted = this.get('hasSubmitted');
+
       if (!hasSubmitted) {
         this.set('hasSubmitted', true);
       }
+
       this.validate().then(() => {
         this.get('target').send('reset', model);
-      }).catch(function(){
+      }).catch( () => {
         // Silence the validation exception
       });
     }

--- a/app/password/reset/route.js
+++ b/app/password/reset/route.js
@@ -2,18 +2,24 @@ import Ember from 'ember';
 import DisallowAuthenticated from "../../mixins/routes/disallow-authenticated";
 
 export default Ember.Route.extend(DisallowAuthenticated, {
-  model: function(){
+  model() {
     return this.store.createRecord('password-reset-request');
   },
 
+  resetController(controller) {
+    controller.setProperties({
+      error: null,
+      hasSubmitted: false
+    });
+  },
+
   actions: {
-    reset: function(model){
+    reset(model) {
       model.save().then( () => {
         this.transitionTo('login');
       }, () => {
-        this.controllerFor('password/reset').set('error', `
-          There was an error resetting your password.
-        `);
+        this.controller.set(
+          'error', `There was an error resetting your password. `);
       });
     },
     willTransition() {

--- a/app/password/reset/template.hbs
+++ b/app/password/reset/template.hbs
@@ -25,6 +25,7 @@
             {{/if}}
             <div class="form-group">
               {{input type="email"
+                name='email'
                 value=model.email
                 class="form-control"
                 placeholder="Email"}}

--- a/app/settings/admin/controller.js
+++ b/app/settings/admin/controller.js
@@ -3,6 +3,11 @@ import Ember from 'ember';
 var and = Ember.computed.and;
 
 export default Ember.Controller.extend({
+  changingPassword: false,
+  changingEmail: false,
+  passwordError: null,
+  emailError: null,
+
   isSavingPassword: and('changingPassword',
                         'session.currentUser.isSaving'),
   isSavingEmail: and('changingEmail',

--- a/app/settings/admin/route.js
+++ b/app/settings/admin/route.js
@@ -1,12 +1,22 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
-  model: function(){
+  model(){
     return this.session.get('currentUser');
   },
 
+  resetController(controller){
+    controller.setProperties({
+      changingEmail: false,
+      changingPassword: false,
+
+      passwordError: null,
+      emailError: null
+    });
+  },
+
   actions: {
-    changePassword: function(){
+    changePassword(){
       var controller = this.controller;
 
       // Changing password is a 2-step process. We show the
@@ -34,30 +44,28 @@ export default Ember.Route.extend({
       });
     },
 
-    changeEmail: function(){
-      var controller = this.controller;
-
+    changeEmail(){
       // Changing email is a 2-step process. We show the
       // "enter current password" input after clicking the button once
-      if (!controller.get('changingEmail')) {
-        controller.set('changingEmail', true);
+      if (!this.controller.get('changingEmail')) {
+        this.controller.set('changingEmail', true);
         return;
       }
 
-      controller.set('emailError', null);
+      this.controller.set('emailError', null);
 
-      var user = this.currentModel;
+      let user = this.currentModel;
 
-      user.save().catch(function(e){
+      user.save().catch( (e) => {
         var message = e.responseJSON ? e.responseJSON.message : e.message;
         if (!message) { message = 'Unknown error'; }
-        controller.set('emailError',message);
-      }).finally(function(){
+        this.controller.set('emailError',message);
+      }).finally( () => {
 
         // Clears the current password input
         user.set('currentPassword', null);
 
-        controller.set('changingEmail', false);
+        this.controller.set('changingEmail', false);
       });
     }
   }


### PR DESCRIPTION
* cleans up some tests to use more es6 and aptibles `expectInput`, `expectButton` etc helpers
  * tests for email/password change clearing errors on accounts/admin and accounts/profile
  * some modification to the tests for password/reset clearing errors

refs #170
fixes #176