### PR TITLE
Various style improvements

### DIFF
--- a/app/app/deploy/template.hbs
+++ b/app/app/deploy/template.hbs
@@ -1,5 +1,5 @@
 <div class="row">
-  <div class="col-xs-10 col-xs-offset-1">
+  <div class="col-xs-8">
     <div class="first-time-app-deploy">
       <h2>Deploy {{model.handle}} in 3 easy steps</h2>
       <div class="panel panel-default panel-steps">
@@ -62,13 +62,10 @@
             </div>
           </div>
         </div>
-        <div class="panel-body-section">
-          <p>
-            If this app was created in error, you can
-            <a href="#" {{action "delete" model}}>destroy {{model.handle}}</a>.
-          </p>
-        </div>
       </div>
+      <p>
+      <a href="#" {{action "delete" model}}>Destroy {{model.handle}}</a>
+      </p>
     </div>
   </div>
 </div>

--- a/app/app/template.hbs
+++ b/app/app/template.hbs
@@ -1,5 +1,7 @@
 {{partial 'app/header'}}
 <div class="container">
-  {{partial 'app/nav'}}
+  {{#if model.hasBeenDeployed}}
+    {{partial 'app/nav'}}
+  {{/if}}
   {{outlet}}
 </div>

--- a/app/components/bs-tooltip/component.js
+++ b/app/components/bs-tooltip/component.js
@@ -22,6 +22,8 @@ export default Ember.Component.extend(BootstrapComponentOptions, {
     var options = this.getBootstrapOptions();
     var tooltip = this.$(':first-child').tooltip(options);
 
-    if(options.trigger = 'immediate') { tooltip.tooltip('show'); }
+    if(options.trigger === 'immediate') {
+      tooltip.tooltip('show');
+    }
   }.on('didInsertElement')
 });

--- a/app/components/git-ref/component.js
+++ b/app/components/git-ref/component.js
@@ -1,0 +1,9 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  attributeBindings: ['title'],
+  classNames: ['git-ref'],
+  shortenedRef: function() {
+    return this.get('gitRef').substring(0,10);
+  }.property('gitRef')
+});

--- a/app/components/git-ref/template.hbs
+++ b/app/components/git-ref/template.hbs
@@ -1,0 +1,13 @@
+{{#bs-tooltip placement="bottom" title=gitRef bs-container=false}}
+  <span>{{shortenedRef}}</span>
+{{/bs-tooltip}}
+
+{{#click-to-copy text=gitRef as |copied|}}
+  {{#if copied}}
+    Copied
+  {{else}}
+    <a href='#'>Copy</a>
+  {{/if}}
+{{/click-to-copy}}
+
+

--- a/app/components/operation-item/template.hbs
+++ b/app/components/operation-item/template.hbs
@@ -1,5 +1,8 @@
 <div class="operation-icon">
-  {{operation-icon type=operation.type status=operation.status}}
+  {{#bs-tooltip placement="bottom"}}
+    {{operation-icon type=operation.type status=operation.status}}
+  {{/bs-tooltip}}
+
 </div>
 
 <div class="operation-author">

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -27,6 +27,7 @@
 @import "components/estimated-cost";
 @import "components/focus";
 @import "components/funnel";
+@import "components/git-ref";
 @import "components/provisioning";
 @import "components/resource-header";
 @import "components/save-progress";

--- a/app/styles/components/git-ref.scss
+++ b/app/styles/components/git-ref.scss
@@ -1,0 +1,5 @@
+.git-ref {
+  .tooltip-inner {
+    max-width: none;
+  }
+}

--- a/app/styles/components/resource-header.scss
+++ b/app/styles/components/resource-header.scss
@@ -77,12 +77,12 @@ header.resource-header {
     text-transform: uppercase;
     font-size: 12px;
     font-weight: $weight-semibold;
-    margin: 0 0 6px;
+    margin: 0 0 9px;
   }
 
   .resource-metadata-value {
-    coor: $color-subdued;
-    font-size: 12px;
+    color: $color-subdued;
+    font-size: 13px;
     font-weight: $weight-normal;
     margin: 0;
 

--- a/app/styles/specific_resources/apps.scss
+++ b/app/styles/specific_resources/apps.scss
@@ -55,7 +55,48 @@
 .first-time-app-deploy {
   h2 {
     font-size: 24px;
-    text-align: center;
-    margin: 30px 0;
+    margin: 0 0 30px;
+  }
+
+  .panel-step-info {
+    p {
+      color: $color-light;
+    }
+
+    *:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+
+
+  .panel-step:first-child {
+    .panel-step-num {
+      border-radius: 3px 0 0 0;
+    }
+
+    .panel-step-info {
+      border-radius: 0 3px 0 0;
+    }
+  }
+
+  .panel-step:last-child {
+    .panel-step-num {
+      border-radius: 0 0 0 3px;
+    }
+
+    .panel-step-info {
+      border-radius: 0 0 3px 0;
+    }
+  }
+
+  .panel-step {
+    .panel-step-num i.fa {
+      font-size: 24px;
+    }
+
+    .panel-step-info {
+      border-left: 1px solid #f0f0f0;
+    }
   }
 }

--- a/app/templates/app/-header.hbs
+++ b/app/templates/app/-header.hbs
@@ -30,15 +30,26 @@
 
         <li class="resource-metadata-item">
           <h5 class="resource-metadata-title">Git Remote</h5>
-          <h3 class="resource-metadata-value">{{model.gitRepo}}</h3>
+          <h3 class="resource-metadata-value">
+            {{model.gitRepo}}
+            {{#click-to-copy text=model.gitRepo as |copied|}}
+              {{#if copied}}
+                Copied
+              {{else}}
+                <a href='#'>Copy</a>
+              {{/if}}
+            {{/click-to-copy}}
+          </h3>
         </li>
 
         {{#if model.currentImage}}
           <li class="resource-metadata-item current-git-ref">
-            <h5 class="resource-metadata-title">Current Git Ref</h5>
-            <h3 class="resource-metadata-value">{{model.currentImage.gitRef}}</h3>
+            <h5 class="resource-metadata-title">Git Ref</h5>
+            <h3 class="resource-metadata-value">{{git-ref gitRef=model.currentImage.gitRef}}</h3>
           </li>
         {{/if}}
+
+
 
         {{#if model.lastDeployOperation}}
           <li class="resource-metadata-item last-deployed-by">

--- a/app/templates/database/-header.hbs
+++ b/app/templates/database/-header.hbs
@@ -18,12 +18,12 @@
 
       {{#if model.stack.allowPHI}}
         <li class="resource-metadata-item">
-          <h5 class="resource-metadata-title">Dedicated Stack</h5>
+          <h5 class="resource-metadata-title">Dedicated Environment</h5>
           <h3 class="resource-metadata-value"><span class="success">PHI Ready</span></h3>
         </li>
       {{else}}
         <li class="resource-metadata-item">
-          <h5 class="resource-metadata-title">Shared Stack</h5>
+          <h5 class="resource-metadata-title">Shared Environment</h5>
           <h3 class="resource-metadata-value"><span class="danger">Not Ready for PHI</span></h3>
         </li>
       {{/if}}
@@ -47,7 +47,16 @@
 
       <li class="resource-metadata-item">
         <h5 class="resource-metadata-title">Connection URL</h5>
-        <h3 class="resource-metadata-value">{{model.connectionUrl}}</h3>
+        <h3 class="resource-metadata-value">
+          {{model.connectionUrl}}
+          {{#click-to-copy text=model.connectionUrl as |copied|}}
+            {{#if copied}}
+              Copied
+            {{else}}
+              <a href='#'>Copy</a>
+            {{/if}}
+          {{/click-to-copy}}
+        </h3>
       </li>
     {{/if}}
 

--- a/app/templates/stack/-header.hbs
+++ b/app/templates/stack/-header.hbs
@@ -7,12 +7,12 @@
 
       {{#if model.allowPHI}}
         <li class="resource-metadata-item">
-          <h5 class="resource-metadata-title">Dedicated Stack</h5>
+          <h5 class="resource-metadata-title">Dedicated Environment</h5>
           <h3 class="resource-metadata-value"><span class="success">PHI Ready</span></h3>
         </li>
       {{else}}
         <li class="resource-metadata-item">
-          <h5 class="resource-metadata-title">Shared Stack</h5>
+          <h5 class="resource-metadata-title">Shared Environment</h5>
           <h3 class="resource-metadata-value"><span class="danger">Not Ready for PHI</span></h3>
         </li>
       {{/if}}

--- a/tests/acceptance/apps/show-empty-test.js
+++ b/tests/acceptance/apps/show-empty-test.js
@@ -60,6 +60,10 @@ function expectNoTab(tabName){
   }
 }
 
+function expectNoTabs() {
+  ok(!!find('.resource-navigation'), 'has no tabs');
+}
+
 test(`visit ${url} when app has not been deployed`, function(assert){
   let sshKeys = [];
   setupAjaxStubs(sshKeys);
@@ -72,15 +76,18 @@ test(`visit ${url} when app has not been deployed`, function(assert){
         'display app handle');
 
     // displayed tabs
-    expectTab('Deploy');
-    expectTab('Activity');
-    expectTab('Deprovision');
+    //expectTab('Deploy');
+    //expectTab('Activity');
+    //expectTab('Deprovision');
 
     // hidden tabs
-    expectNoTab('Services');
-    expectNoTab('Domains');
+    //expectNoTab('Services');
+    //expectNoTab('Domains');
 
     // displayed steps
+
+    expectNoTabs();
+
     let steps = [
       {title: 'Add your SSH Key', links: ['settings/ssh', gettingStartedLink]},
       {title: 'Add a Procfile to your App', links:[gettingStartedLink]},
@@ -143,7 +150,7 @@ test(`visit ${url} when app has not been deployed, click destroy link`, function
   setupAjaxStubs([]);
   signInAndVisit(url);
 
-  click(`a:contains(destroy ${appHandle})`);
+  click(`a:contains(Destroy ${appHandle})`);
   andThen(function(){
     equal(currentPath(), 'stack.apps.new', 'redirected to apps');
   });

--- a/tests/acceptance/apps/show-test.js
+++ b/tests/acceptance/apps/show-test.js
@@ -22,7 +22,7 @@ test('visiting /apps/my-app-id shows basic app info', function() {
   var serviceId = 'service-1';
 
   let deployUserName = 'Skylar Anderson';
-  let currentGitRef = 'b2bac0d8f9d5ab83ae2cc879b05cb8b61ca628ce';
+  let currentGitRef = 'b2bac0d8f9';
 
   stubStack({
     id: 'my-stack-1',

--- a/tests/acceptance/stack/show-test.js
+++ b/tests/acceptance/stack/show-test.js
@@ -94,7 +94,7 @@ test(`visit ${url} shows basic stack info`, function() {
     expectLink(`stacks/${stackId}/logging`);
     expectLink(`stacks/${stackId}/apps`);
 
-    ok(find('h5:contains(Shared Stack)').length,
+    ok(find('h5:contains(Shared Environment)').length,
        'has shared stack header');
 
     ok(find(`h1:contains(${stackHandle})`).length,

--- a/tests/unit/components/git-ref-test.js
+++ b/tests/unit/components/git-ref-test.js
@@ -5,11 +5,10 @@ import {
 
 import Ember from 'ember';
 
-moduleForComponent('operation-item', 'OperationItemComponent', {
+moduleForComponent('git-ref', 'GitRefComponent', {
   needs: [
-    'component:operation-icon',
-    'component:bs-tooltip',
-    'helper:format-utc-timestamp'
+    'component:click-to-copy',
+    'component:bs-tooltip'
   ]
 });
 
@@ -18,12 +17,7 @@ test('it renders', function() {
 
   // creates the component instance
   var component = this.subject({
-    operation: Ember.Object.create({
-      type: 'provision',
-      status: 'running',
-      userName: 'Test User',
-      createdAt: new Date()
-    })
+    gitRef: '60b04a6c76cf2a171893640de9a54cc92730c592'
   });
 
   equal(component._state, 'preRender');

--- a/tests/unit/components/operation-icon-test.js
+++ b/tests/unit/components/operation-icon-test.js
@@ -6,7 +6,7 @@ import {
 import Ember from 'ember';
 
 moduleForComponent('operation-icon', 'OperationIconComponent', {
-  needs: []
+  needs: ['component:bs-tooltip']
 });
 
 test('it renders', function() {


### PR DESCRIPTION
* Shortens the viewable git ref to first 10 characters.  The entire ref is viewable in a tooltip and copyable with click-to-copy component
* Added click-to-copy to other long fields: git ref, git remote, and DB connection URL
* Increased font size for resource meta
* Hides app nav if the app has never been deployed

cc @mixonic 