### PR TITLE
add pending invitations page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ npm-debug.log
 testem.log
 /.divshot-cache
 travis-env.sh
+*.swp

--- a/app/models/invitation.js
+++ b/app/models/invitation.js
@@ -1,0 +1,9 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  email: DS.attr('string'),
+  createdAt: DS.attr('date'),
+  updatedAt: DS.attr('date'),
+
+  role: DS.belongsTo('role', {async:true})
+});

--- a/app/models/organization.js
+++ b/app/models/organization.js
@@ -1,6 +1,8 @@
 import DS from 'ember-data';
 import Ember from 'ember';
 
+let orgRegex = new RegExp('organizations/([a-zA-Z0-9\-]+)');
+
 export default DS.Model.extend({
   name: DS.attr('string'),
   primaryPhone: DS.attr('string'),
@@ -11,13 +13,14 @@ export default DS.Model.extend({
   address: DS.attr('string'),
   plan: DS.attr('string'),
 
-  users: DS.hasMany('users', {async: true}),
+  users: DS.hasMany('user', {async: true}),
+  invitations: DS.hasMany('invitation', {async:true}),
 
+  // needed by aptible-ability
   permitsRole(role, scope){
     return new Ember.RSVP.Promise( (resolve) => {
       let roleOrganizationHref = role.get('data.links.organization');
-      let regex = /organizations\/(.*)/;
-      let match = regex.exec(roleOrganizationHref);
+      let match = orgRegex.exec(roleOrganizationHref);
       let roleOrganizationId = match[1];
 
       let result = roleOrganizationId === this.get('id');

--- a/app/organization/invitations/route.js
+++ b/app/organization/invitations/route.js
@@ -1,0 +1,13 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  model(){
+    let organization = this.modelFor('organization');
+    return organization.get('invitations');
+  },
+
+  setupController(controller, model){
+    controller.set('model', model);
+    controller.set('organization', this.modelFor('organization'));
+  }
+});

--- a/app/organization/invitations/template.hbs
+++ b/app/organization/invitations/template.hbs
@@ -1,0 +1,55 @@
+<div class="panel">
+  <div class="panel-heading">
+    <h3>Pending Invitations</h3>
+  </div>
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>Email</th>
+        <th>Role</th>
+        <th>Date Sent</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      {{#each model as |invitation|}}
+        <tr>
+          <td>{{invitation.email}}</td>
+          <td>{{invitation.role.name}}</td>
+          <td>{{invitation.updatedAt}}</td>
+          <td>
+            {{#aptible-ability
+                user=session.currentUser
+                scope='manage'
+                permittable=organization as |hasAbility|}}
+              {{#if hasAbility}}
+                <div class="table-row-nav">
+                  <ul class="nav nav-pills sub-nav-tabs">
+                    <li>
+                      {{! FIXME should link to an edit membership page}}
+                      <a href="#" title="Resend invitation to {{invitation.email}}">
+                        <i class="fa fa-refresh"></i>
+                        <span class="button-label">
+                          Resend
+                        </span>
+                      </a>
+                    </li>
+                    <li>
+                      {{! FIXME should fire action that calls deletion }}
+                      <a href="#" title="Delete invitation for {{invitation.email}}">
+                        <i class="fa fa-times"></i>
+                        <span class="button-label">
+                          Remove
+                        </span>
+                      </a>
+                    </li>
+                  </ul>
+                </div>
+              {{/if}}
+            {{/aptible-ability}}
+          </td>
+        </tr>
+      {{/each}}
+    </tbody>
+  </table>
+</div>

--- a/app/organization/route.js
+++ b/app/organization/route.js
@@ -2,17 +2,26 @@ import Ember from 'ember';
 import { replaceLocation } from "../utils/location";
 import config from '../config/environment';
 
+let resolve;
+
+// needed to allow tests to finish,
+// force-resolves the promise that is intended to hang while
+// the page is reloaded
+export function forcePromiseResolution() {
+  resolve();
+}
+
 export default Ember.Route.extend({
   beforeModel: function() {
     var params = this.paramsFor('organization');
-    this._super.apply(this, arguments).then(() => {
+    return this._super.apply(this, arguments).then(() => {
       if (!this.features.isEnabled('organization-settings')) {
-        replaceLocation();
         var host = config.aptibleHosts['legacy-dashboard'];
         var url = [host, 'organizations', params.organization_id].join('/');
         replaceLocation(url);
+
         // Hang this transition
-        return new Ember.RSVP.Promise(() => {});
+        return new Ember.RSVP.Promise(r => resolve = r);
       }
     });
   }

--- a/app/organization/template.hbs
+++ b/app/organization/template.hbs
@@ -15,8 +15,8 @@
         {{#activating-item currentWhen="organization.members" tagName="li"}}
           {{link-to "Members" "organization.members"}}
         {{/activating-item}}
-        {{#activating-item currentWhen="index" tagName="li"}}
-          {{link-to "Invitations" "index"}}
+        {{#activating-item currentWhen="organization.invitations" tagName="li"}}
+          {{link-to "Invitations" "organization.invitations"}}
         {{/activating-item}}
         {{#activating-item currentWhen="index" tagName="li"}}
           {{link-to "Roles" "index"}}

--- a/app/router.js
+++ b/app/router.js
@@ -80,6 +80,7 @@ Router.map(function() {
 
   this.route("organization", {path: "/organizations/:organization_id"}, function() {
     this.route("members");
+    this.route("invitations");
   });
 });
 

--- a/tests/acceptance/organization-test.js
+++ b/tests/acceptance/organization-test.js
@@ -4,6 +4,7 @@ import {
   test
 } from 'qunit';
 import startApp from 'diesel/tests/helpers/start-app';
+import { forcePromiseResolution } from 'diesel/organization/route';
 
 var application;
 
@@ -21,7 +22,12 @@ test('visiting /organization without organizationSettings feature redirects', fu
   stubOrganization({ id: 42 });
   setFeature('organization-settings', false);
   signInAndVisit('/organizations/42');
-  locationUpdatedTo('http://localhost:3000/organizations/42');
+  setTimeout(() => {
+    // this is needed so that the test will not hang indefinitely waiting
+    // for a promise that will never resolve
+    forcePromiseResolution();
+    locationUpdatedTo('http://localhost:3000/organizations/42');
+  }, 0);
 });
 
 test('visiting /organization', function(assert) {
@@ -30,5 +36,6 @@ test('visiting /organization', function(assert) {
   signInAndVisit('/organizations/42');
   andThen(function() {
     assert.equal(currentPath(), 'organization.members');
+    expectLink('/organizations/42/invitations');
   });
 });

--- a/tests/acceptance/organization/invitations-test.js
+++ b/tests/acceptance/organization/invitations-test.js
@@ -1,0 +1,70 @@
+import Ember from 'ember';
+import {
+  module,
+  test
+} from 'qunit';
+import startApp from 'diesel/tests/helpers/start-app';
+import {stubRequest} from 'diesel/tests/helpers/fake-server';
+
+let application;
+let orgId = 'o1'; // FIXME this is hardcoded to match the value for signIn in aptible-helpers
+let url = `/organizations/${orgId}/invitations`;
+let invitationsUrl = url;
+
+module('Acceptance: Organizations: Invitations', {
+  beforeEach: function() {
+    application = startApp();
+  },
+
+  afterEach: function() {
+    Ember.run(application, 'destroy');
+  }
+});
+
+test(`visiting ${url} requires authentication`, () => {
+  expectRequiresAuthentication(url);
+});
+
+test(`visiting ${url} shows pending invites`, (assert) => {
+  let roleUrl = '/roles/role1';
+  let invitations = [{
+    id: 'invite1',
+    email: 'bob@invite1.com',
+    roleName: 'owners',
+    _links: { role: { href: roleUrl } }
+  }];
+
+  assert.expect(3 + 2*invitations.length);
+
+  stubOrganization({
+    id:orgId,
+    _links: { invitations: {href: invitationsUrl} }
+  });
+
+  stubRequest('get', invitationsUrl, function(request){
+    assert.ok(true, `gets ${invitationsUrl}`);
+    return this.success({ _embedded: { invitations } });
+  });
+
+  stubRequest('get', roleUrl, function(request){
+    assert.ok(true, `gets ${roleUrl}`);
+    return this.success({
+      id: 'role1',
+      name: invitations[0].roleName
+    });
+  });
+
+  signInAndVisit(url);
+  andThen(() => {
+    equal(currentPath(), 'organization.invitations');
+
+    invitations.forEach( (i) => {
+      assert.ok(find(`:contains(${i.email})`).length,
+                `shows invitation email "${i.email}"`);
+      assert.ok(find(`:contains(${i.roleName})`).length,
+                `shows invitation role "${i.roleName}"`);
+    });
+  });
+});
+
+// FIXME wire up the resend and delete buttons and test them here

--- a/tests/acceptance/organization/members-test.js
+++ b/tests/acceptance/organization/members-test.js
@@ -7,10 +7,18 @@ import startApp from 'diesel/tests/helpers/start-app';
 import {stubRequest} from 'diesel/tests/helpers/fake-server';
 
 var application;
+let orgId = 'big-co';
+let url = `/organizations/${orgId}/members`;
+let membersUrl = `/organizations/${orgId}/users`;
 
 module('Acceptance: OrganizationMembers', {
   beforeEach: function() {
     application = startApp();
+    stubOrganization({
+      id: orgId,
+      _links: { users: { href: membersUrl } }
+    });
+
   },
 
   afterEach: function() {
@@ -18,19 +26,13 @@ module('Acceptance: OrganizationMembers', {
   }
 });
 
-test('visiting /organizations/big-co/members', function(assert) {
-  assert.expect(4);
-  let organizationId = 'big-co';
-  let membersUrl = '/organizations/'+organizationId+'/users';
+test(`visiting ${url} requires authentication`, function(){
+  expectRequiresAuthentication(url);
+});
 
-  stubOrganization({
-    id: organizationId,
-    _links: {
-      users: {
-        href: membersUrl
-      }
-    }
-  });
+test(`visiting ${url}`, function(assert) {
+  assert.expect(4);
+
   stubRequest('get', membersUrl, function(request){
     assert.ok(true, 'Request for members is made');
     return this.success({
@@ -56,6 +58,7 @@ test('visiting /organizations/big-co/members', function(assert) {
       }
     });
   });
+
   stubRequest('get', '/users/bob/roles', function(request){
     return this.success({
       _embedded: {
@@ -63,6 +66,7 @@ test('visiting /organizations/big-co/members', function(assert) {
       }
     });
   });
+
   stubRequest('get', '/users/mike/roles', function(request){
     return this.success({
       _embedded: {
@@ -71,7 +75,7 @@ test('visiting /organizations/big-co/members', function(assert) {
     });
   });
 
-  signInAndVisit('/organizations/big-co/members');
+  signInAndVisit(`/organizations/${orgId}/members`);
 
   andThen(function() {
     assert.equal(currentPath(), 'organization.members');

--- a/tests/helpers/aptible-helpers.js
+++ b/tests/helpers/aptible-helpers.js
@@ -3,11 +3,6 @@ import { locationHistory } from '../../utils/location';
 import { titleHistory } from '../../utils/title-route-extensions';
 import { stubRequest } from "./fake-server";
 
-/**
- * @param userData object populate the signed-in user with this data.
- *   If `privileged` is true, the user will be marked as privileged.
- *   This property can be used to ensure `User#can` returns true
- */
 Ember.Test.registerAsyncHelper('signIn', function(app, userData){
   userData = userData || {};
   let defaultUserData = {

--- a/tests/support/common-model-dependencies.js
+++ b/tests/support/common-model-dependencies.js
@@ -14,6 +14,7 @@ export default [
   'model:user',
   'model:token',
   'model:ssh-key',
+  'model:invitation',
 
   'adapter:application',
   'serializer:application',

--- a/tests/unit/models/invitation-test.js
+++ b/tests/unit/models/invitation-test.js
@@ -1,0 +1,16 @@
+import {
+  moduleForModel,
+  test
+} from 'ember-qunit';
+import modelDeps from '../../support/common-model-dependencies';
+
+moduleForModel('invitation', {
+  // Specify the other units that are required for this test.
+  needs: modelDeps
+});
+
+test('it exists', function(assert) {
+  var model = this.subject();
+  // var store = this.store();
+  assert.ok(!!model);
+});


### PR DESCRIPTION
Adds a pending invitations page at /organizations/:id/invitations
the lists invited users and the role they are invited to.

The resend/delete links do not work.