### PR TITLE
Add a confirmation modal and use it for deleting roles

### DIFF
--- a/app/adapters/role.js
+++ b/app/adapters/role.js
@@ -1,0 +1,3 @@
+import AuthAdapter from './auth';
+
+export default AuthAdapter.extend();

--- a/app/application/template.hbs
+++ b/app/application/template.hbs
@@ -1,1 +1,3 @@
-{{outlet}}
+{{#confirmation-modal}}
+  {{outlet}}
+{{/confirmation-modal}}

--- a/app/components/confirmation-modal/component.js
+++ b/app/components/confirmation-modal/component.js
@@ -1,0 +1,44 @@
+import Ember from 'ember';
+import layout from './template';
+
+export default Ember.Component.extend({
+  confirmationModalService: Ember.inject.service('confirmation-modal'),
+  layout: layout,
+
+  model: Ember.computed.reads('modal.model'),
+
+  startConfirmationModalServiceListener: function() {
+    this._super.apply(this, arguments);
+    this.get('confirmationModalService').on('open', (modal) => {
+      this.set('modal', modal);
+      this.set('isOpen', true);
+    });
+  }.on('init'),
+
+  close() {
+    this.set('isOpen', false);
+    this.set('modal', null);
+  },
+
+  actions: {
+
+    cancel() {
+      let modal = this.get('modal');
+      new Ember.RSVP.Promise((resolve) => {
+        resolve(modal && modal.onCancel && modal.onCancel());
+      }).then(() => {
+        this.close();
+      });
+    },
+
+    confirm() {
+      let modal = this.get('modal');
+      new Ember.RSVP.Promise((resolve) => {
+        resolve(modal && modal.onConfirm && modal.onConfirm());
+      }).then(() => {
+        this.close();
+      });
+    }
+
+  }
+});

--- a/app/components/confirmation-modal/template.hbs
+++ b/app/components/confirmation-modal/template.hbs
@@ -1,0 +1,5 @@
+{{#if isOpen}}
+  {{partial modal.partial}}
+{{else}}
+  {{yield}}
+{{/if}}

--- a/app/organization/roles/controller.js
+++ b/app/organization/roles/controller.js
@@ -1,10 +1,24 @@
 import Ember from "ember";
 
 export default Ember.Controller.extend({
+
+  confirmationModalService: Ember.inject.service('confirmation-modal'),
+
   actions: {
     inviteTo(role) {
       let organization = this.get('organization');
       this.transitionToRoute('organization.invite', organization, {queryParams: {role}});
+    },
+    delete(role) {
+      this.get('confirmationModalService').open({
+        partial: 'confirmation-modals/delete-role',
+        model: role,
+        onConfirm: () => {
+          role.deleteRecord();
+          return role.save();
+        }
+      });
     }
   }
+
 });

--- a/app/organization/roles/template.hbs
+++ b/app/organization/roles/template.hbs
@@ -41,8 +41,7 @@
                       </a>
                     </li>
                     <li>
-                      {{! FIXME should fire action that calls deletion }}
-                      <a href="#" title="Delete {{role.name}} role">
+                      <a href="#" title="Delete {{role.name}} role" {{action "delete" role}}>
                         <i class="fa fa-times"></i>
                       </a>
                     </li>

--- a/app/services/confirmation-modal.js
+++ b/app/services/confirmation-modal.js
@@ -1,0 +1,9 @@
+import Ember from 'ember';
+
+export default Ember.Service.extend(Ember.Evented, {
+
+  open(modal){
+    this.trigger('open', modal);
+  }
+
+});

--- a/app/templates/confirmation-modals/delete-role.hbs
+++ b/app/templates/confirmation-modals/delete-role.hbs
@@ -1,0 +1,20 @@
+{{#login-box}}
+  <div class="row">
+    <div class="col-xs-6 col-xs-offset-3">
+      <div class="panel panel-subdued panel-focused">
+        <div class="panel-heading">
+          <h3>Really delete {{model.name}}?</h3>
+        </div>
+        <div class="panel-body">
+          <p>
+            Deleting the role {{model.name}} cannot be
+            undone.
+          </p>
+
+          <button class="btn btn-default btn-block btn-lg" {{action "cancel"}}>cancel</button>
+          <button class="btn btn-primary btn-block btn-lg" {{action "confirm"}}>confirm deletion</button>
+        </div>
+      </div>
+    </div>
+  </div>
+{{/login-box}}

--- a/tests/acceptance/organization/roles-test.js
+++ b/tests/acceptance/organization/roles-test.js
@@ -58,7 +58,6 @@ test(`visiting ${url} shows roles`, (assert) => {
 
 test(`visit ${url} and click to add a user`, (assert) => {
   assert.expect(3);
-
   stubOrganization({
     id: orgId,
     _links: {
@@ -86,4 +85,31 @@ test(`visit ${url} and click to add a user`, (assert) => {
   });
 });
 
-// FIXME wire up the resend and delete buttons and test them here
+test(`visit ${url} and delete a role`, (assert) => {
+  assert.expect(2);
+  stubOrganization({
+    id: orgId,
+    _links: {
+      roles: {href: rolesUrl}
+    }
+  });
+
+  let role = {
+    id: 'role1',
+    name: 'Owner'
+  };
+
+  stubRequest('get', rolesUrl, function(request){
+    assert.ok(true, `gets ${rolesUrl}`);
+    return this.success({ _embedded: { roles: [role] }});
+  });
+
+  stubRequest('delete', `/roles/${role.id}`, function(request){
+    assert.ok(true, `deletes the role`);
+    return this.noContent();
+  });
+
+  signInAndVisit(url);
+  click(`a[title="Delete ${role.name} role"]`);
+  clickButton('confirm deletion');
+});

--- a/tests/unit/components/confirmation-modal/component-test.js
+++ b/tests/unit/components/confirmation-modal/component-test.js
@@ -1,0 +1,108 @@
+import {
+  moduleForComponent,
+  test
+} from 'ember-qunit';
+import Ember from "ember";
+
+let MockService = Ember.Object.extend(Ember.Evented);
+let confirmationModalService;
+
+moduleForComponent('confirmation-modal', {
+  subject(options, klass) {
+    options = options || {};
+    options.confirmationModalService = confirmationModalService = MockService.create();
+    return klass.create(options);
+  }
+});
+
+test('it can open', function(assert) {
+  assert.expect(2);
+
+  var component = this.subject();
+  assert.ok(!component.get('isOpen'), 'is not open');
+
+  confirmationModalService.trigger('open', {});
+  assert.ok(component.get('isOpen'), 'is open');
+});
+
+test('it can have a model', function(assert) {
+  assert.expect(2);
+
+  var component = this.subject();
+  assert.ok(!component.get('model'), 'has no model');
+
+  confirmationModalService.trigger('open', {model: {isModel: true}});
+  assert.ok(component.get('model').isModel, 'has a model');
+});
+
+test('can be cancelled', function(assert) {
+  assert.expect(3);
+
+  var component = this.subject();
+  confirmationModalService.trigger('open', {
+    model: {isModel: true},
+    onCancel(){
+      assert.ok(true, 'fires callback on cancel');
+    }
+  });
+
+  Ember.run(component, 'send', 'cancel');
+  assert.equal(component.get('model'), null, 'unsets model');
+  assert.equal(component.get('isOpen'), false, 'closes');
+});
+
+test('can be cancelled with promise', function(assert) {
+  assert.expect(4);
+
+  let resolve;
+  var component = this.subject();
+  confirmationModalService.trigger('open', {
+    model: {isModel: true},
+    onCancel(){
+      assert.ok(true, 'fires callback on cancel');
+      return new Ember.RSVP.Promise(r => resolve = r);
+    }
+  });
+
+  Ember.run(component, 'send', 'cancel');
+  assert.equal(component.get('isOpen'), true, 'stays open');
+  Ember.run(null, resolve);
+  assert.equal(component.get('model'), null, 'unsets model');
+  assert.equal(component.get('isOpen'), false, 'closes');
+});
+
+test('can be confirmed', function(assert) {
+  assert.expect(3);
+
+  var component = this.subject();
+  confirmationModalService.trigger('open', {
+    model: {isModel: true},
+    onConfirm(){
+      assert.ok(true, 'fires callback on confirm');
+    }
+  });
+
+  Ember.run(component, 'send', 'confirm');
+  assert.equal(component.get('model'), null, 'unsets model');
+  assert.equal(component.get('isOpen'), false, 'closes');
+});
+
+test('can be confirmed with promise', function(assert) {
+  assert.expect(4);
+
+  let resolve;
+  var component = this.subject();
+  confirmationModalService.trigger('open', {
+    model: {isModel: true},
+    onConfirm(){
+      assert.ok(true, 'fires callback on confirm');
+      return new Ember.RSVP.Promise(r => resolve = r);
+    }
+  });
+
+  Ember.run(component, 'send', 'confirm');
+  assert.equal(component.get('isOpen'), true, 'stays open');
+  Ember.run(null, resolve);
+  assert.equal(component.get('model'), null, 'unsets model');
+  assert.equal(component.get('isOpen'), false, 'closes');
+});

--- a/tests/unit/services/confirmation-modal-test.js
+++ b/tests/unit/services/confirmation-modal-test.js
@@ -1,0 +1,15 @@
+import {
+  moduleFor,
+  test
+} from 'ember-qunit';
+
+moduleFor('service:confirmation-modal');
+
+test('it fires events', function(assert) {
+  assert.expect(1);
+  var service = this.subject();
+  service.on('open', (data) => {
+    assert.ok(data.isMyData, 'data is passed through');
+  });
+  service.open({ isMyData: true });
+});


### PR DESCRIPTION
Add a service that can be used for triggering a confirmation modal. For example:

```javascript
export default Ember.Component.extend({
  confirmationModalService = Ember.inject.service('confirmation-modal'),
  actions: {
    delete(thing) {
      this.get('confirmationModalService').open({
        partial: 'confirmation-modals/some-partial-template', // Is looked up as a partial
        model: thing, // Is made available in the partial
        onConfirm() {
          thing.deleteRecord();
          return thing.save(); // The modal will not close until a returned promise has completed
        } // onCancel also available
      });
    }
  }
});
```

Uses this for role deletion.

![](http://g.recordit.co/GscOBsnlEH.gif)

Fixes #206 
