### PR TITLE
Enable the invite-to-role link

### DIFF
--- a/app/organization/invite/route.js
+++ b/app/organization/invite/route.js
@@ -2,8 +2,18 @@ import Ember from 'ember';
 import DS from 'ember-data';
 
 export default Ember.Route.extend({
-  model(){
-    return this.store.createRecord('invitation');
+  queryParams: {
+    role: {
+      replace: true
+    }
+  },
+
+  model(params, transition){
+    let options = {};
+    if (transition.queryParams.role) {
+      options.role = transition.queryParams.role;
+    }
+    return this.store.createRecord('invitation', options);
   },
 
   afterModel(){

--- a/app/organization/roles/controller.js
+++ b/app/organization/roles/controller.js
@@ -1,0 +1,10 @@
+import Ember from "ember";
+
+export default Ember.Controller.extend({
+  actions: {
+    inviteTo(role) {
+      let organization = this.get('organization');
+      this.transitionToRoute('organization.invite', organization, {queryParams: {role}});
+    }
+  }
+});

--- a/app/organization/roles/route.js
+++ b/app/organization/roles/route.js
@@ -10,4 +10,5 @@ export default Ember.Route.extend({
     controller.set('model', model);
     controller.set('organization', this.modelFor('organization'));
   }
+
 });

--- a/app/organization/roles/template.hbs
+++ b/app/organization/roles/template.hbs
@@ -36,8 +36,7 @@
                       </a>
                     </li>
                     <li>
-                      {{! FIXME should link to add a new user}}
-                      <a href="#" title="Invite new user to {{role.name}} by email">
+                      <a href="#" title="Invite new user to {{role.name}} by email" {{action "inviteTo" role}}>
                         <i class="fa fa-envelope"></i>
                       </a>
                     </li>

--- a/tests/acceptance/organization/roles-test.js
+++ b/tests/acceptance/organization/roles-test.js
@@ -56,4 +56,34 @@ test(`visiting ${url} shows roles`, (assert) => {
   });
 });
 
+test(`visit ${url} and click to add a user`, (assert) => {
+  assert.expect(3);
+
+  stubOrganization({
+    id: orgId,
+    _links: {
+      roles: {href: rolesUrl}
+    }
+  });
+
+  let role = {
+    id: 'role1',
+    name: 'Owner'
+  };
+
+  stubRequest('get', rolesUrl, function(request){
+    return this.success({ _embedded: { roles: [role] }});
+  });
+
+  signInAndVisit(url);
+  andThen(() => {
+    assert.equal(currentPath(), 'organization.roles');
+  });
+  click(`a[title="Invite new user to ${role.name} by email"]`);
+  andThen(() => {
+    assert.equal(currentPath(), 'organization.invite');
+    assert.equal(find('select').val(), role.name, 'role is selected');
+  });
+});
+
 // FIXME wire up the resend and delete buttons and test them here


### PR DESCRIPTION
Clicking the invite-user-to-role link takes the user to the new invite page with that role selected.

Fixes #212