### PR TITLE
bs-alert sends an action when it is dismissed

### DIFF
--- a/app/components/bs-alert-dismiss/component.js
+++ b/app/components/bs-alert-dismiss/component.js
@@ -11,10 +11,10 @@
      {{/bs-alert}}
   {{/bs-alert}}
 
-  * If used in inline style, this will insert a pulled-right "X":
+  * If used in inline style, this will insert a pulled-right "X" (this is the bootstrap default)
 
    {{#bs-alert as |component|}}
-     {{bs-alert-dismiss target=component}}
+     {{bs-alert-dismiss target=component}} {{! inline style}}
    {{/bs-alert}}
  */
 import Ember from 'ember';
@@ -22,6 +22,7 @@ import Ember from 'ember';
 export default Ember.Component.extend({
   tagName: 'span',
   action: 'dismiss',
+  classNames: ['bs-alert-dismiss'],
 
   click: function(e){
     e.preventDefault();

--- a/app/components/bs-alert/component.js
+++ b/app/components/bs-alert/component.js
@@ -4,8 +4,13 @@
  * Required params: none
  * Optional params:
  *   * alert: name of alert. Default: 'warning'
+ *   * action: This action will be sent when the alert is dismissed.
+ *             This can be necessary to ensure the bs-alert is cleared and
+ *             re-rendered when it is reused to display multiple messages on a page.
+ *             See https://github.com/aptible/diesel.aptible.com/issues/223
  *
-  {{#bs-alert alert='success'}}
+  {{#bs-alert action="clearSuccessMessage" alert='success' as |component|}}
+    {{bs-alert-dismiss target=component}} {{! when dismissed, "clearSuccessMessage" action is sent}}
     Here is some success alert text
   {{/bs-alert}}
 
@@ -28,6 +33,7 @@ export default Ember.Component.extend({
   actions: {
     dismiss: function(){
       this.set('isVisible', false);
+      this.sendAction();
     }
   }
 });

--- a/app/organization/invitations/route.js
+++ b/app/organization/invitations/route.js
@@ -22,6 +22,11 @@ export default Ember.Route.extend({
         let message = `Deleted invitation for ${invitation.get('email')}`;
         this.controller.set('successMessage', message);
       });
+    },
+
+    // sent by the bs-alert component when it is dismissed
+    clearSuccessMessage(){
+      this.controller.set('successMessage', null);
     }
   }
 });

--- a/app/organization/invitations/template.hbs
+++ b/app/organization/invitations/template.hbs
@@ -4,7 +4,7 @@
   </div>
 
   {{#if successMessage}}
-    {{#bs-alert alert="success" as |component|}}
+    {{#bs-alert alert="success" action="clearSuccessMessage" as |component|}}
       {{bs-alert-dismiss target=component}}
       {{successMessage}}
     {{/bs-alert}}

--- a/tests/acceptance/organization/invitations-test.js
+++ b/tests/acceptance/organization/invitations-test.js
@@ -16,6 +16,11 @@ let invitations = [{
   email: 'bob@invite1.com',
   roleName: 'owners',
   _links: { role: { href: roleUrl } }
+}, {
+  id: 'invite2',
+  email: 'bob2@invite1.com',
+  roleName: 'owners',
+  _links: { role: { href: roleUrl } }
 }];
 
 module('Acceptance: Organizations: Invitations', {
@@ -81,7 +86,7 @@ test(`visiting ${url} and clicking "refresh" sends the invite again`, (assert) =
   });
 
   signInAndVisit(url);
-  click('a[title*="Resend invitation"]');
+  click('a[title*="Resend invitation"]:eq(0)');
   andThen(() => {
     assert.ok(find('.alert-success').length,
               'shows success message');
@@ -89,10 +94,10 @@ test(`visiting ${url} and clicking "refresh" sends the invite again`, (assert) =
 });
 
 test(`visiting ${url} and clicking "destroy" destroys the invite`, (assert) => {
-  assert.expect(4);
-  let invitationId = invitations[0].id;
+  assert.expect(7);
 
-  stubRequest('delete', `/invitations/${invitationId}`, function(request){
+  // called for each deleted invitation (2x)
+  stubRequest('delete', `/invitations/:invite_id`, function(request){
     assert.ok(true, 'deletes the invitation');
     return this.success(204, {});
   });
@@ -102,12 +107,22 @@ test(`visiting ${url} and clicking "destroy" destroys the invite`, (assert) => {
     assert.ok(find(`:contains(${invitations[0].email})`).length,
               'precond - shows invitation email');
   });
-  click('a[title*="Delete invitation"]');
+  click('a[title*="Delete invitation"]:eq(0)');
   andThen(() => {
     assert.ok(find(`:contains(${invitations[0].email})`).length,
               'no longer shows invitation email');
 
     assert.ok(find('.alert-success').length,
               'shows success message');
+    click('.alert-success .bs-alert-dismiss');
+  });
+  andThen(() => {
+    assert.ok(!find('.alert-success').length,
+              'hides success message');
+    click('a[title*="Delete invitation"]:eq(0)');
+  });
+  andThen(() => {
+    assert.ok(find('.alert-success').length,
+              'shows success message again');
   });
 });


### PR DESCRIPTION
This allows consumers to react to the dismissal, and helps in cases
where we are reusing the same bs-alert with different messages, to
ensure that the component is torn down and re-rendered, rather than
staying around stuck in its hidden state.

fixes #223

@mixonic for your review, in case there's a better way to "reset" this component.
If it is possible for it to observe its template contents then it could flip
from hidden -> visible when the contents change. I'm not sure if that's easy to do, though.