### PR TITLE
Add subscribeAll to changeset, disable last checked role on edit memberships

### DIFF
--- a/app/components/organization-membership-checkbox/component.js
+++ b/app/components/organization-membership-checkbox/component.js
@@ -2,9 +2,11 @@ import Ember from 'ember';
 
 export default Ember.Component.extend({
   tagName: 'input',
-  attributeBindings: ['type', 'checked', 'name'],
+  attributeBindings: ['type', 'checked', 'name', 'disabled'],
   type: 'checkbox',
   name: 'user-role',
+
+  disabled: Ember.computed.reads('isDisabled'),
   checked: Ember.computed.reads('isChecked'),
 
   init(){
@@ -15,15 +17,29 @@ export default Ember.Component.extend({
       user: this.user
     };
 
+    this.updateUI();
+    this.changeset.subscribeAll(() => this.updateUI());
+  },
+
+  updateUI() {
     this.updateCheckbox();
-    this.changeset.subscribe(this._stagedObjectKey, () => {
-      this.updateCheckbox();
-    });
+    this.updateDisabled();
   },
 
   updateCheckbox() {
     const isChecked = this.changeset.value(this._stagedObjectKey);
     this.set('isChecked', isChecked);
+  },
+
+  updateDisabled() {
+    let activeMemberships = [];
+    this.changeset.forEachValue((keyData, initialValue, value) => {
+      if (value === true) { activeMemberships.push(keyData); }
+    });
+    const isDisabled = activeMemberships.length === 1 &&
+      activeMemberships[0] === this._stagedObjectKey;
+
+    this.set('isDisabled', isDisabled);
   },
 
   click() {

--- a/app/organization/members/edit/route.js
+++ b/app/organization/members/edit/route.js
@@ -33,7 +33,9 @@ export default Ember.Route.extend({
       const changeset = this.controller.get('changeset');
       let promise;
 
-      changeset.forEachChangedValue((keyData, initialValue, value) => {
+      changeset.forEachValue((keyData, initialValue, value) => {
+        if (initialValue === value) { return; }
+
         let user = this.currentModel;
         let userLink = user.get('data.links.self');
         let role     = keyData.organizationRole;

--- a/app/organization/roles/edit/route.js
+++ b/app/organization/roles/edit/route.js
@@ -59,7 +59,9 @@ export default Ember.Route.extend({
       const savePromises = [];
       const changeset = this.controller.get('changeset');
 
-      changeset.forEachChangedValue((keyData, initialValue, value) => {
+      changeset.forEachValue((keyData, initialValue, value) => {
+        if (initialValue === value) { return; }
+
         let promise;
         if (value.isEnabled) {
           promise = this.store.createRecord('permission', {

--- a/tests/acceptance/organization/members/edit-test.js
+++ b/tests/acceptance/organization/members/edit-test.js
@@ -139,10 +139,39 @@ test(`visiting ${url} allows changing user's roles`, function(assert){
     secondRole = findWithAssert(`.role:eq(1)`);
     firstInput = findInput('user-role', {context:firstRole});
     secondInput = findInput('user-role', {context:secondRole});
-    click(firstInput);  // -> unchecked, delete this membership
     click(secondInput);  // -> checked,  create this membership
+    click(firstInput);  // -> unchecked, delete this membership
   });
   andThen(() => {
     clickButton('Update User Roles');
+  });
+});
+
+test(`visiting ${url} with only 1 role checked is disabled`, function(assert){
+  assert.expect(6);
+
+  let firstRole, secondRole, firstInput, secondInput;
+
+  signInAndVisit(url);
+  andThen(() => {
+    firstRole = findWithAssert(`.role:eq(0)`);
+    secondRole = findWithAssert(`.role:eq(1)`);
+    firstInput = findInput('user-role', {context:firstRole});
+    secondInput = findInput('user-role', {context:secondRole});
+
+    assert.ok(firstInput.is(':disabled'), 'precond - only checked input is disabled');
+    assert.ok(!secondInput.is(':disabled'), 'precond - second, unchecked input not disabled');
+
+    click(secondInput);  // -> checked,  create this membership
+  });
+  andThen(() => {
+    assert.ok(!firstInput.is(':disabled'), 'first input is no longer disabled');
+    assert.ok(!secondInput.is(':disabled'), 'second input still not disabled');
+
+    click(firstInput);  // -> unchecked, now only the 2nd input is checked
+  });
+  andThen(() => {
+    assert.ok(!firstInput.is(':disabled'), 'first input is not disabled');
+    assert.ok(secondInput.is(':disabled'), 'second input is disabled because it is the only one checked');
   });
 });

--- a/tests/unit/components/organization-membership-checkbox/component-test.js
+++ b/tests/unit/components/organization-membership-checkbox/component-test.js
@@ -11,11 +11,17 @@ moduleForComponent('organization-membership-checkbox', {
 test('it renders', function(assert) {
   assert.expect(2);
 
-  // creates the component instance
-  var component = this.subject({changeset: {value: function(){}, subscribe: function(){}}});
+  let noop = function(){};
+  let mockChangeset = {
+    value: noop,
+    subscribe: noop,
+    subscribeAll: noop,
+    forEachValue: noop
+  };
+
+  var component = this.subject({changeset: mockChangeset});
   assert.equal(component._state, 'preRender');
 
-  // renders the component to the page
   this.render();
   assert.equal(component._state, 'inDOM');
 });

--- a/tests/unit/utils/changeset-test.js
+++ b/tests/unit/utils/changeset-test.js
@@ -93,6 +93,42 @@ test('subscription hook is notified of changes', (assert) => {
   assert.equal(passedValues[1], 'def');
 });
 
+test('subscribeAll is notified of every `setValue` call', (assert) => {
+  assert.expect(2);
+
+  let keyData1 = {a:1};
+  let keyData2 = {a:2};
+  let notifs = [];
+
+  changeset.subscribeAll((sourceKeyData) => {
+    notifs.push(sourceKeyData);
+  });
+
+  changeset.setValue(keyData1, 'abc');
+  assert.deepEqual(notifs, [keyData1], 'called with the sourceKeyData');
+
+  changeset.setValue(keyData2, 'def');
+  assert.deepEqual(notifs, [keyData1, keyData2], 'called again with the second sourceKeyData');
+});
+
+test('subscribeAll is notified on initial `value` call', (assert) => {
+  assert.expect(2);
+
+  let keyData1 = {a:1};
+  let keyData2 = {a:2};
+  let notifs = [];
+
+  changeset.subscribeAll((sourceKeyData) => {
+    notifs.push(sourceKeyData);
+  });
+
+  changeset.value(keyData1);
+  assert.deepEqual(notifs, [keyData1], 'called with the sourceKeyData');
+
+  changeset.value(keyData2);
+  assert.deepEqual(notifs, [keyData1, keyData2], 'called again with the second sourceKeyData');
+});
+
 test('forEachValue yields final set value', (assert) => {
   assert.expect(3);
   changeset.setValue(keyData, 'v1');
@@ -143,29 +179,4 @@ test('forEachValue returns values that are read but not set', (assert) => {
   changeset.forEachValue((_keyData) => {
     assert.equal(_keyData, keyData, 'forEachValue yields for the keyData that was read');
   });
-});
-
-test('forEachChangedValue skips values that did not change', (assert) => {
-  changeset = Changeset.create({
-    key(keyData){
-      return keyData.key;
-    },
-    initialValue(keyData){
-      return keyData.value;
-    }
-  });
-
-  let changedKeyData = [];
-  let keyData1 = {key:'1', value:'foo'};
-  let keyData2 = {key:'2', value:'bar'};
-  let keyData3 = {key:'3', value:'baz'};
-
-  changeset.setValue(keyData1, 'first thing');
-  changeset.setValue(keyData3, 'third thing');
-
-  changeset.forEachChangedValue((_keyData, initialValue, value) => {
-    changedKeyData.push(_keyData);
-  });
-
-  assert.deepEqual(changedKeyData, [keyData1, keyData3]);
 });


### PR DESCRIPTION
Adds a `subscribeAll` method to the Changeset util, and uses this to update the disabled property on the checkboxes for role memberships on `/organizations/:id/members/:member_id/edit`.

refs #228