### PR TITLE
change buildURLWithPrefixMapping to have {property:X, only:Y} values

### DIFF
--- a/app/adapters/app.js
+++ b/app/adapters/app.js
@@ -3,6 +3,6 @@ import buildURLWithPrefixMap from '../utils/build-url-with-prefix-map';
 
 export default ApplicationAdapter.extend({
   buildURL: buildURLWithPrefixMap({
-    'accounts': 'stack.id'
+    'accounts': {property: 'stack.id', only: ['create', 'update']}
   })
 });

--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -2,10 +2,11 @@ import HalAdapter from "ember-data-hal-9000/adapter";
 import DS from "ember-data";
 import Ember from "ember";
 import config from "../config/environment";
+import LookupMethodsWithRequestTypesMixin from "../mixins/adapters/-lookup-methods-with-request-types";
 
 export var auth = {};
 
-export default HalAdapter.extend({
+export default HalAdapter.extend(LookupMethodsWithRequestTypesMixin, {
 
   host: config.apiBaseUri,
 
@@ -35,16 +36,5 @@ export default HalAdapter.extend({
     } else {
       return error;
     }
-  },
-
-  deleteRecord: function(store, type, record){
-    var id = Ember.get(record, 'id');
-    var url = this.buildURL(type.typeKey, id);
-    return this.ajax(url, "DELETE");
-  },
-
-  find: function(store, type, id /*, record */) {
-    return this.ajax(this.buildURL(type.typeKey, id), 'GET');
   }
-
 });

--- a/app/adapters/database.js
+++ b/app/adapters/database.js
@@ -3,6 +3,6 @@ import buildURLWithPrefixMap from '../utils/build-url-with-prefix-map';
 
 export default ApplicationAdapter.extend({
   buildURL: buildURLWithPrefixMap({
-    'accounts': 'stack.id'
+    'accounts': {property: 'stack.id', only:['create','update']}
   })
 });

--- a/app/adapters/invitation.js
+++ b/app/adapters/invitation.js
@@ -3,6 +3,6 @@ import buildURLWithPrefixMap from '../utils/build-url-with-prefix-map';
 
 export default AuthAdapter.extend({
   buildURL: buildURLWithPrefixMap({
-    'roles': 'role.id'
+    'roles': {property: 'role.id', only:['create','update']}
   })
 });

--- a/app/adapters/log-drain.js
+++ b/app/adapters/log-drain.js
@@ -4,7 +4,7 @@ import Ember from 'ember';
 
 export default ApplicationAdapter.extend({
   buildURL: buildURLWithPrefixMap({
-    'accounts': 'stack.id'
+    'accounts': {property: 'stack.id'}
   }),
 
   // In URLs and JSON payloads, use "log_drains" instead of "logDrains"

--- a/app/adapters/membership.js
+++ b/app/adapters/membership.js
@@ -3,6 +3,6 @@ import buildURLWithPrefixMap from '../utils/build-url-with-prefix-map';
 
 export default AuthAdapter.extend({
   buildURL: buildURLWithPrefixMap({
-    'roles': 'role.id'
+    'roles': {property: 'role.id', only: ['create','update']}
   })
 });

--- a/app/adapters/operation.js
+++ b/app/adapters/operation.js
@@ -3,23 +3,26 @@ import buildURLWithPrefixMap from '../utils/build-url-with-prefix-map';
 
 export default ApplicationAdapter.extend({
   buildURL: buildURLWithPrefixMap({
-    'databases':   'database.id',
-    'apps':        'app.id',
-    'vhosts':      'vhost.id',
-    'log_drains':  'logDrain.id',
-    'services':    'service.id'
+    'databases':   {property: 'database.id'},
+    'apps':        {property: 'app.id'},
+    'vhosts':      {property: 'vhost.id'},
+    'log_drains':  {property: 'logDrain.id'},
+    'services':    {property: 'service.id'}
   }),
 
   findQuery: function(store, type, query){
-    var url;
+    let url = this.buildURL(type.typeKey, null, null, 'findQuery');
+
+    if (this.sortQueryParams) {
+      query = this.sortQueryParams(query);
+    }
+
     if (query.app) {
-      url = this.buildURL(type.typeKey, null, {app: query.app});
+      url = url.replace('/operations', `/apps/${query.app.id}/operations`);
       delete query.app;
     } else if (query.database) {
-      url = this.buildURL(type.typeKey, null, {database: query.database});
+      url = url.replace('/operations', `/databases/${query.database.id}/operations`);
       delete query.database;
-    } else {
-      url = this.buildURL(type.typeKey);
     }
 
     return this.ajax(url, 'GET', {data:query});

--- a/app/adapters/password-reset-request.js
+++ b/app/adapters/password-reset-request.js
@@ -1,8 +1,6 @@
 import AuthAdapter from "./auth";
 import Ember from "ember";
 
-export var auth = {};
-
 export default AuthAdapter.extend({
 
   buildURL: function(){

--- a/app/adapters/permission.js
+++ b/app/adapters/permission.js
@@ -3,6 +3,6 @@ import buildURLWithPrefixMap from '../utils/build-url-with-prefix-map';
 
 export default ApplicationAdapter.extend({
   buildURL: buildURLWithPrefixMap({
-    'accounts': 'stack.id'
+    'accounts': {property: 'stack.id', only:['create','update']}
   })
 });

--- a/app/adapters/role.js
+++ b/app/adapters/role.js
@@ -1,30 +1,8 @@
 import AuthAdapter from './auth';
 import buildURLWithPrefixMap from '../utils/build-url-with-prefix-map';
-import Ember from 'ember';
 
 export default AuthAdapter.extend({
   buildURL: buildURLWithPrefixMap({
-    'organizations': 'organization.id'
-  }),
-
-  // https://github.com/emberjs/data/blob/ff35ee78bfac058afb7a715a5dfc5760218cc05c/packages/ember-data/lib/adapters/rest-adapter.js#L561
-  // To update a Role, the adapter should send a PUT request to /roles/:id,
-  // so we override updateRecord and remove the prepended /organizations/:organization
-  // that `buildURL` adds
-  updateRecord: function(store, type, snapshot){
-    let data = {};
-    let serializer = store.serializerFor(type.typeKey);
-
-    serializer.serializeIntoHash(data, type, snapshot);
-
-    let id = snapshot.id;
-    let url = this.buildURL(type.typeKey, id, snapshot, 'updateRecord');
-
-    let organizationId = Ember.get(snapshot, 'organization.id');
-    if (organizationId) {
-      url = url.replace(`/organizations/${organizationId}`, "");
-    }
-
-    return this.ajax(url, "PUT", { data: data });
-  }
+    'organizations': {property: 'organization.id', only: ['create']}
+  })
 });

--- a/app/adapters/ssh-key.js
+++ b/app/adapters/ssh-key.js
@@ -4,25 +4,8 @@ import Ember from 'ember';
 
 export default AuthAdapter.extend({
   buildURL: buildURLWithPrefixMap({
-    'users': 'user.id'
+    'users': {property: 'user.id', only:['create']}
   }),
-
-  // To delete an ssh-key, the adapter should send a DELETE to /ssh_keys/:id,
-  // but it POSTs to /users/:user_id/ssh_keys.
-  // Override deleteRecord to remove the "/users/:user_id" from the
-  // url for a DELETE.
-  deleteRecord: function(store, type, record){
-    var id = Ember.get(record, 'id');
-    var userId = Ember.get(record, 'user.id');
-
-    var url = this.buildURL(type.typeKey, id, record);
-
-    if (userId) {
-      url = url.replace("/users/" + userId, "");
-    }
-
-    return this.ajax(url, "DELETE");
-  },
 
   // In URLs and JSON payloads, use "ssh_keys" instead of "sshKeys"
   pathForType: function(type){

--- a/app/adapters/subscription.js
+++ b/app/adapters/subscription.js
@@ -3,6 +3,6 @@ import buildURLWithPrefixMap from '../utils/build-url-with-prefix-map';
 
 export default AuthAdapter.extend({
   buildURL: buildURLWithPrefixMap({
-    'organizations': 'organization.id'
+    'organizations': {property: 'organization.id'}
   })
 });

--- a/app/adapters/vhost.js
+++ b/app/adapters/vhost.js
@@ -1,31 +1,8 @@
 import ApplicationAdapter from './application';
 import buildURLWithPrefixMap from '../utils/build-url-with-prefix-map';
-import Ember from 'ember';
 
 export default ApplicationAdapter.extend({
   buildURL: buildURLWithPrefixMap({
-    'services': 'service.id'
-  }),
-
-  // https://github.com/emberjs/data/blob/64ccb96673b2396dc16424b8ab1271afa43134ca/packages/ember-data/lib/adapters/rest_adapter.js#L549
-  // To update a VHost, the adapter should send a PUT request to /vhosts/:id,
-  // so we override updateRecord and remove the prepended /services/:service_id
-  // that `buildURL` adds
-  updateRecord: function(store, type, record){
-    var data = {};
-    var serializer = store.serializerFor(type.typeKey);
-
-    var snapshot = record._createSnapshot();
-    serializer.serializeIntoHash(data, type, snapshot);
-
-    var id = Ember.get(record, 'id');
-
-    var serviceId = Ember.get(record, 'service.id');
-    var url = this.buildURL(type.typeKey, id, record);
-    if (serviceId) {
-      url = url.replace("/services/" + serviceId, "");
-    }
-
-    return this.ajax(url, "PUT", { data: data });
-  }
+    'services': {property: 'service.id', only:['create']}
+  })
 });

--- a/app/mixins/adapters/-lookup-methods-with-request-types.js
+++ b/app/mixins/adapters/-lookup-methods-with-request-types.js
@@ -1,0 +1,93 @@
+import Ember from 'ember';
+let get = Ember.get;
+
+// `requestType` is passed as the 4th argument to buildURL as of https://github.com/emberjs/data/commit/e8ceeeb4c099ab084a603c2b2564c56197c65fc5
+// This is not yet in a released version of ember-data but we need it to enable
+// fine-grained control over our URLs (to make it easy to prepend a string to the URL only for deletes, say),
+// so we pull in that code here
+//
+// After the next ember-data release (> 1.0.0.beta-16.1), this mixin
+// should be able to be removed (and the ApplicationAdapter can stop extending it)
+
+export default Ember.Mixin.create({
+  deleteRecord: function(store, type, snapshot){
+    let id = snapshot.id;
+    let url = this.buildURL(type.typeKey, id, snapshot, 'deleteRecord');
+    return this.ajax(url, "DELETE");
+  },
+
+  find: function(store, type, id, snapshot) {
+    return this.ajax(this.buildURL(type.typeKey, id, snapshot, 'find'), 'GET');
+  },
+
+  findAll: function(store, type, sinceToken) {
+    var query, url;
+
+    if (sinceToken) {
+      query = { since: sinceToken };
+    }
+
+    url = this.buildURL(type.typeKey, null, null, 'findAll');
+
+    return this.ajax(url, 'GET', { data: query });
+  },
+
+  findQuery: function(store, type, query) {
+    var url = this.buildURL(type.typeKey, null, null, 'findQuery');
+
+    if (this.sortQueryParams) {
+      query = this.sortQueryParams(query);
+    }
+
+    return this.ajax(url, 'GET', { data: query });
+  },
+
+  findMany: function(store, type, ids, snapshots) {
+    var url = this.buildURL(type.typeKey, ids, snapshots, 'findMany');
+    return this.ajax(url, 'GET', { data: { ids: ids } });
+  },
+
+  findHasMany: function(store, snapshot, url/*, relationship*/) {
+    var host = get(this, 'host');
+    var id   = snapshot.id;
+    var type = snapshot.typeKey;
+
+    if (host && url.charAt(0) === '/' && url.charAt(1) !== '/') {
+      url = host + url;
+    }
+
+    url = this.urlPrefix(url, this.buildURL(type, id, null, 'findHasMany'));
+
+    return this.ajax(url, 'GET');
+  },
+
+  findBelongsTo: function(store, snapshot, url/*, relationship*/) {
+    var id   = snapshot.id;
+    var type = snapshot.typeKey;
+
+    url = this.urlPrefix(url, this.buildURL(type, id, null, 'findBelongsTo'));
+    return this.ajax(url, 'GET');
+  },
+
+  createRecord: function(store, type, snapshot) {
+    var data = {};
+    var serializer = store.serializerFor(type.typeKey);
+    var url = this.buildURL(type.typeKey, null, snapshot, 'createRecord');
+
+    serializer.serializeIntoHash(data, type, snapshot, { includeId: true });
+
+    return this.ajax(url, "POST", { data: data });
+  },
+
+  updateRecord: function(store, type, snapshot) {
+    var data = {};
+    var serializer = store.serializerFor(type.typeKey);
+
+    serializer.serializeIntoHash(data, type, snapshot);
+
+    var id = snapshot.id;
+    var url = this.buildURL(type.typeKey, id, snapshot, 'updateRecord');
+
+    return this.ajax(url, "PUT", { data: data });
+  }
+});

--- a/app/utils/build-url-with-prefix-map.js
+++ b/app/utils/build-url-with-prefix-map.js
@@ -1,21 +1,80 @@
 import Ember from 'ember';
 
+// Iterates through the items in the `prefixMapping` object and calls
+// the callback for each prefixMapping that applies to this requestType.
+// `requestType` is passed as the 4th argument to buildURL as of https://github.com/emberjs/data/commit/e8ceeeb4c099ab084a603c2b2564c56197c65fc5
+// We use the mixins/adapters/-lookup-methods-with-request-types mixin
+// to add this `requestType` parameter until an ember-data version is released
+// that has the requestType param.
+//
+// The callback is called with (prefixName, prefixPropName).
+//
+// The mapping can be an object with string keys and string values, or object values
+// that specify which request types are applicable.
+//
+// Example:
+// {
+//   'accounts': {property: 'stack.id', only:['create']}
+// }
+// This will result in prepending the string "/accounts/${record.get('stack.id')}"
+// to create requests.
+// `eachApplicablePrefixPropertyMapping` will invoke the callback once with ('accounts', 'stack.id')
+// if the requestType matches 'create'.
+//
+// See the model unit tests for more.
+
+function eachApplicablePrefixPropertyMapping(prefixMapping, requestType, callback){
+  Ember.keys(prefixMapping).forEach( (prefixName) => {
+    let prefixPropertyMapping = prefixMapping[prefixName];
+
+    let prefixPropName = prefixPropertyMapping.property;
+    let conditions     = prefixPropertyMapping.only || [];
+
+    if (checkConditions(requestType, conditions)) {
+      callback(prefixName, prefixPropName);
+    }
+  });
+}
+
+function checkConditions(requestType, conditions){
+  if (conditions.length === 0) { return true; }
+
+  requestType = requestType.toLowerCase();
+  return conditions.any((condition) => requestType.match(condition));
+}
+
+/*
+ * `prefixPropertyMapping` is an object with a key that is the string value
+ * to prepend to the url and an object value that has the property to check for on
+ * the record and an optional `only` prop of request types to include
+ * {
+ *   'accounts': {property: 'stack.id', only:['create']}
+ * }
+ * Prepends `accounts/${record.get('stack.id')}` when the requestType matches 'create'.
+ * Valid values of only are:
+ *   * find
+ *   * create
+ *   * update
+ *   * delete
+ */
 export default function buildURLWithPrefixMap(prefixPropertyMapping){
-  // From ember-data's buildURL: https://github.com/emberjs/data/blob/9e9a78111825d4154522cba8ddbbe679c56c9e5c/packages/ember-data/lib/adapters/rest_adapter.js#L532-L550
-  return function buildURL(type, id, record) {
-    var url = [],
+  // From ember-data's buildURL: https://github.com/emberjs/data/blob/ff35ee78bfac058afb7a715a5dfc5760218cc05c/packages/ember-data/lib/adapters/build-url-mixin.js#L51
+  return function buildURL(type, id, snapshot, requestType) {
+    let url = [],
         host = Ember.get(this, 'host'),
         prefix = this.urlPrefix();
 
     if (type) {
 
-      // loop through prefix map {prefixName -> propName}
-      // If any property exists on the record, prepend both the prefix name
-      // and the property value.
-      Ember.keys(prefixPropertyMapping).forEach(function(prefixName){
-        var prefixPropName = prefixPropertyMapping[prefixName];
+      // loop through prefix map {prefixName -> (propName OR propObject)}
+      // If the requestType is not applicable (i.e. does not match the `propObject.only` array), skip.
+      // else:
+      //   If the propName property exists on the snapshot, prepend both the prefix name
+      //   and the propName property value.
+      eachApplicablePrefixPropertyMapping(prefixPropertyMapping, requestType, (prefixName, prefixPropName) => {
+        let record = snapshot && snapshot.record;
+        let prefixProp = record ? record.get(prefixPropName) : null;
 
-        var prefixProp = record ? Ember.get(record, prefixPropName) : null;
 
         if (prefixProp) {
           // add /prefixName/prefixProp to url

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "ember-cli-inject-live-reload": "^1.3.0",
     "ember-cli-pretender": "^0.3.1",
     "ember-cli-qunit": "0.3.9",
-    "ember-data": "1.0.0-beta.16",
+    "ember-data": "1.0.0-beta.16.1",
     "ember-data-hal-9000": "0.1.6",
     "ember-export-application-global": "^1.0.2",
     "ember-feature-flags": "1.0.0",

--- a/tests/acceptance/apps/deprovision-test.js
+++ b/tests/acceptance/apps/deprovision-test.js
@@ -56,11 +56,12 @@ test('/apps/:id/deprovision will deprovision with confirmation', function(){
     handle: appName,
     status: 'provisioned',
     _links: {
-      account: {href: '/accounts/1'}
+      account: {href: '/accounts/1'},
+      self: {href: `/apps/${appId}` }
     }
   });
 
-  stubRequest('post', '/apps/'+appId+'/operations', function(request){
+  stubRequest('post', `/apps/${appId}/operations`, function(request){
     didDeprovision = true;
     return this.success({
       id: '1',
@@ -73,7 +74,7 @@ test('/apps/:id/deprovision will deprovision with confirmation', function(){
   stubOrganization();
   stubOrganizations();
 
-  signInAndVisit('/apps/'+appId+'/deprovision');
+  signInAndVisit(`/apps/${appId}/deprovision`);
   fillIn('input[type=text]', appName);
   andThen(function(){
     $('input[type=text]').trigger('input');

--- a/tests/acceptance/databases/deprovision-test.js
+++ b/tests/acceptance/databases/deprovision-test.js
@@ -55,11 +55,12 @@ test('/databases/:id/deprovision will deprovision with confirmation', function()
     id: databaseId,
     handle: databaseName,
     _links: {
-      account: {href: '/accounts/1'}
+      account: {href: '/accounts/1'},
+      self: {href: `/databases/${databaseId}`}
     }
   });
 
-  stubRequest('post', '/databases/'+databaseId+'/operations', function(request){
+  stubRequest('post', `/databases/${databaseId}/operations`, function(request){
     didDeprovision = true;
     return this.success({
       id: '1',

--- a/tests/unit/models/app-test.js
+++ b/tests/unit/models/app-test.js
@@ -7,19 +7,20 @@ import modelDeps from '../../support/common-model-dependencies';
 
 import Ember from 'ember';
 
-moduleForModel('app', 'App', {
+moduleForModel('app', 'model:app', {
   needs: modelDeps.concat([
     'adapter:app',
     'adapter:operation', // for 'operation', to avoid getting the fixture adapter
   ])
 });
 
-test('finding uses correct url', function(){
+test('finding uses correct url', function(assert){
+  let done = assert.async();
   expect(2);
 
-  var appId = 'my-app-id';
+  let appId = 'my-app-id';
 
-  stubRequest('get', '/apps/' + appId, function(request){
+  stubRequest('get', `/apps/${appId}`, function(request){
     ok(true, 'calls with correct URL');
 
     return this.success({
@@ -31,12 +32,31 @@ test('finding uses correct url', function(){
     });
   });
 
-  var store = this.store();
+  let store = this.store();
 
   return Ember.run(function(){
     return store.find('app', appId).then(function(){
       ok(true, 'app did find');
-    });
+    }).finally(done);
+  });
+});
+
+test('reloading app with stack uses correct url', function(assert){
+  assert.expect(1);
+  let done = assert.async();
+  let store = this.store();
+
+  let app = Ember.run(store, 'push', 'app', {id:'app1'});
+  let stack = Ember.run(store, 'push', 'stack', {id:'stack1'});
+
+  stubRequest('get', `/apps/app1`, function(request){
+    assert.ok(true, 'gets correct url');
+    return this.success({id:'app1'});
+  });
+
+  Ember.run(() => {
+    app.set('stack', stack);
+    app.reload().finally(done);
   });
 });
 

--- a/tests/unit/models/database-test.js
+++ b/tests/unit/models/database-test.js
@@ -7,7 +7,7 @@ import modelDeps from '../../support/common-model-dependencies';
 
 import Ember from 'ember';
 
-moduleForModel('database', 'Database', {
+moduleForModel('database', 'model:database', {
   // Specify the other units that are required for this test.
   needs: modelDeps.concat([
     'adapter:database'
@@ -36,6 +36,26 @@ test('finding uses correct url', function(){
     return store.find('database', dbId).then(function(){
       ok(true, 'database did find');
     });
+  });
+});
+
+test('reloading uses correct url', function(assert){
+  let done = assert.async();
+  assert.expect(1);
+
+  let store = this.store();
+  let dbId = 'db-id';
+  let db = Ember.run(store, 'push', 'database', {id:dbId});
+  let stack = Ember.run(store, 'push', 'stack', {id:'stackid'});
+
+  stubRequest('get', `/databases/${dbId}`, function(request){
+    assert.ok(true, 'calls with correct URL');
+    return this.success({id: dbId});
+  });
+
+  Ember.run(() => {
+    db.set('stack',stack);
+    db.reload().finally(done);
   });
 });
 

--- a/tests/unit/models/image-test.js
+++ b/tests/unit/models/image-test.js
@@ -4,7 +4,7 @@ import {
 } from 'ember-qunit';
 import modelDeps from '../../support/common-model-dependencies';
 
-moduleForModel('image', {
+moduleForModel('image', 'model:image', {
   // Specify the other units that are required for this test.
   needs: modelDeps
 });

--- a/tests/unit/models/invitation-test.js
+++ b/tests/unit/models/invitation-test.js
@@ -6,7 +6,7 @@ import modelDeps from '../../support/common-model-dependencies';
 import Ember from 'ember';
 import { stubRequest } from '../../helpers/fake-server';
 
-moduleForModel('invitation', {
+moduleForModel('invitation', 'model:invitation', {
   // Specify the other units that are required for this test.
   needs: modelDeps.concat([
     'adapter:invitation'
@@ -30,5 +30,26 @@ test('creating POSTS to a url prefixed with roles/:id', function(assert) {
 
   Ember.run(() => {
     model.save().finally(done);
+  });
+});
+
+test('deletes by DELETEing to /invitations/:id', function(assert){
+  let done = assert.async();
+  assert.expect(1);
+  let store = this.store();
+  let invitation, role;
+
+  Ember.run(() => {
+    role = store.push('role',{id:'r1'});
+    invitation = store.push('invitation',{id:'i1', role});
+  });
+
+  stubRequest('delete', '/invitations/i1', function(request){
+    assert.ok(true);
+    return this.noContent();
+  });
+
+  Ember.run(() => {
+    invitation.destroyRecord().finally(done);
   });
 });

--- a/tests/unit/models/membership-test.js
+++ b/tests/unit/models/membership-test.js
@@ -6,7 +6,7 @@ import Ember from 'ember';
 import modelDeps from "../../support/common-model-dependencies";
 import { stubRequest } from '../../helpers/fake-server';
 
-moduleForModel('membership', {
+moduleForModel('membership', 'model:membership', {
   // Specify the other units that are required for this test.
   needs: modelDeps.concat([
     'adapter:membership'
@@ -29,5 +29,26 @@ test('create POSTs to /roles/:role_id/memberships with user url', function(asser
 
   Ember.run(() => {
     model.save().finally(done);
+  });
+});
+
+test('destroy DELETEs to /memberships/:id', function(assert){
+  assert.expect(1);
+  let done = assert.async();
+  let store = this.store();
+  let membership, role;
+
+  Ember.run(() => {
+    role = store.push('role', {id:'r1'});
+    membership = store.push('membership', {id:'m1', role});
+  });
+
+  stubRequest('delete', `/memberships/m1`, function(request){
+    assert.ok(true, 'deletes to correct url');
+    return this.noContent();
+  });
+
+  Ember.run(() => {
+    membership.destroyRecord().finally(done);
   });
 });

--- a/tests/unit/models/operation-test.js
+++ b/tests/unit/models/operation-test.js
@@ -6,17 +6,11 @@ import { stubRequest } from "../../helpers/fake-server";
 import Ember from 'ember';
 import modelDeps from '../../support/common-model-dependencies';
 
-moduleForModel('operation', 'Operation', {
+moduleForModel('operation', 'model:operation', {
   // Specify the other units that are required for this test.
   needs: modelDeps.concat([
     'adapter:operation'
   ])
-});
-
-test('it exists', function() {
-  var model = this.subject();
-  // var store = this.store();
-  ok(!!model);
 });
 
 test('when creating an operation for a db, POSTs to /databases/:id/operations', function(){

--- a/tests/unit/models/organization-test.js
+++ b/tests/unit/models/organization-test.js
@@ -4,7 +4,7 @@ import {
 } from 'ember-qunit';
 import modelDeps from '../../support/common-model-dependencies';
 
-moduleForModel('organization', 'Organization', {
+moduleForModel('organization', 'model:organization', {
   // Specify the other units that are required for this test.
   needs: modelDeps
 });

--- a/tests/unit/models/password-reset-request-test.js
+++ b/tests/unit/models/password-reset-request-test.js
@@ -3,7 +3,7 @@ import {
   test
 } from 'ember-qunit';
 
-moduleForModel('password-reset-request', {
+moduleForModel('password-reset-request', 'model:password-reset-request', {
   // Specify the other units that are required for this test.
   needs: []
 });

--- a/tests/unit/models/permission-test.js
+++ b/tests/unit/models/permission-test.js
@@ -35,3 +35,24 @@ test('to create, it POSTs to /accounts/:id/permissions', function(assert){
     permission.save().finally(done);
   });
 });
+
+test('deletes by DELETEing to /permissions/:id', function(assert){
+  let done = assert.async();
+  assert.expect(1);
+  let store = this.store();
+  let permission, stack;
+
+  Ember.run(() => {
+    stack = store.push('stack',{id:'s1'});
+    permission = store.push('permission',{id:'p1', stack});
+  });
+
+  stubRequest('delete', '/permissions/p1', function(request){
+    assert.ok(true);
+    return this.noContent();
+  });
+
+  Ember.run(() => {
+    permission.destroyRecord().finally(done);
+  });
+});

--- a/tests/unit/models/reset-test.js
+++ b/tests/unit/models/reset-test.js
@@ -6,7 +6,7 @@ import modelDeps from '../../support/common-model-dependencies';
 import { stubRequest } from '../../helpers/fake-server';
 import Ember from 'ember';
 
-moduleForModel('reset', {
+moduleForModel('reset', 'model:reset', {
   // Specify the other units that are required for this test.
   needs: modelDeps.concat([
     'adapter:reset'

--- a/tests/unit/models/role-test.js
+++ b/tests/unit/models/role-test.js
@@ -57,3 +57,24 @@ test('updates by PUTting to /roles/:role_id', function(assert){
     role.save().finally(done);
   });
 });
+
+test('destroy DELETEs to /roles/:id', function(assert){
+  assert.expect(1);
+  let done = assert.async();
+  let store = this.store();
+  let role, organization;
+
+  Ember.run(() => {
+    organization = store.push('organization', {id:'o1'});
+    role = store.push('role', {id:'r1', organization});
+  });
+
+  stubRequest('delete', `/roles/r1`, function(request){
+    assert.ok(true, 'deletes to correct url');
+    return this.noContent();
+  });
+
+  Ember.run(() => {
+    role.destroyRecord().finally(done);
+  });
+});

--- a/tests/unit/models/service-test.js
+++ b/tests/unit/models/service-test.js
@@ -4,7 +4,7 @@ import {
 } from 'ember-qunit';
 import modelDeps from '../../support/common-model-dependencies';
 
-moduleForModel('service', 'Service', {
+moduleForModel('service', 'model:service', {
   // Specify the other units that are required for this test.
   needs: modelDeps
 });

--- a/tests/unit/models/ssh-key-test.js
+++ b/tests/unit/models/ssh-key-test.js
@@ -4,31 +4,51 @@ import {
 } from 'ember-qunit';
 import { stubRequest } from "../../helpers/fake-server";
 import Ember from 'ember';
+import modelDeps from '../../support/common-model-dependencies';
 
-moduleForModel('ssh-key', 'SshKey', {
+moduleForModel('ssh-key', 'model:ssh-key', {
   // Specify the other units that are required for this test.
-  needs: [
-    'model:role',
-    'model:organization',
-    'model:user',
-    'model:token',
-
-    'adapter:application',
-    'adapter:ssh-key',
-    'adapter:user',
-    'serializer:application',
-  ]
+  needs: modelDeps.concat([
+    'adapter:ssh-key'
+  ])
 });
 
-/*
- * There is a bug in the interaction between ember data and the
- * isolated container used in `moduleForModel` unit tests
- * that causes issues unit-testing this ssh-key model.
- * The store will end up incorrectly unable to find the model
- * when it calls `modelFor('sshKey')`.
- * More details are here: https://github.com/bantic/data/pull/1
- *
- * There should be tests here that POSTing and DELETEing ssh keys
- * use the correct urls (/users/:user_id/ssh_keys and /ssh_keys/:ssh_key_id
- * for the latter, respectively).
- */
+test('posts to /users/:id/ssh_keys', function(assert){
+  let done = assert.async();
+  assert.expect(1);
+  let user, key;
+  let store = this.store();
+  Ember.run(() => {
+    user = store.push('user',{id:'u1'});
+  });
+
+  stubRequest('post', '/users/u1/ssh_keys', function(request){
+    assert.ok(true, 'posts to correct url');
+    return this.success({id:'k1'});
+  });
+
+  Ember.run(() => {
+    key = store.createRecord('ssh-key', {user});
+    key.save().finally(done);
+  });
+});
+
+test('deletes to /ssh_keys/:id', function(assert){
+  let done = assert.async();
+  assert.expect(1);
+  let user, key;
+  let store = this.store();
+  Ember.run(() => {
+    user = store.push('user',{id:'u1'});
+    key = store.push('ssh-key',{id:'k1',user});
+  });
+
+  stubRequest('delete', '/ssh_keys/k1', function(request){
+    assert.ok(true, 'deletes to correct url');
+    return this.noContent();
+  });
+
+  Ember.run(() => {
+    key.destroyRecord().finally(done);
+  });
+});

--- a/tests/unit/models/stack-test.js
+++ b/tests/unit/models/stack-test.js
@@ -6,7 +6,7 @@ import { stubRequest } from "../../helpers/fake-server";
 import Ember from 'ember';
 import modelDeps from '../../support/common-model-dependencies';
 
-moduleForModel('stack', 'Stack', {
+moduleForModel('stack', 'model:stack', {
   // Specify the other units that are required for this test.
   needs: modelDeps
 });

--- a/tests/unit/models/subscription-test.js
+++ b/tests/unit/models/subscription-test.js
@@ -6,7 +6,7 @@ import Ember from "ember";
 import { stubRequest } from '../../helpers/fake-server';
 import modelDeps from '../../support/common-model-dependencies';
 
-moduleForModel('subscription', 'Subscription', {
+moduleForModel('subscription', 'model:subscription', {
   needs: modelDeps.concat(['adapter:subscription'])
 });
 

--- a/tests/unit/models/user-test.js
+++ b/tests/unit/models/user-test.js
@@ -4,7 +4,7 @@ import {
 } from 'ember-qunit';
 import modelDeps from "../../support/common-model-dependencies";
 
-moduleForModel('user', 'User', {
+moduleForModel('user', 'model:user', {
   // Specify the other units that are required for this test.
   needs: modelDeps
 });

--- a/tests/unit/models/vhost-test.js
+++ b/tests/unit/models/vhost-test.js
@@ -7,18 +7,19 @@ import modelDeps from '../../support/common-model-dependencies';
 
 import Ember from 'ember';
 
-moduleForModel('vhost', 'Vhost', {
+moduleForModel('vhost', 'model:vhost', {
   // Specify the other units that are required for this test.
   needs: modelDeps.concat([
     'adapter:vhost'
   ])
 });
 
-test('creating POSTs to correct url', function() {
-  expect(2);
+test('creating POSTs to correct url', function(assert) {
+  let done = assert.async();
+  assert.expect(1);
 
-  var store = this.store();
-  var vhost, service;
+  let store = this.store();
+  let vhost, service;
 
   Ember.run(function(){
     service = store.createRecord('service', {id: '1'});
@@ -26,35 +27,31 @@ test('creating POSTs to correct url', function() {
   });
 
   stubRequest('post', '/services/1/vhosts', function(request){
-    ok(true, 'calls with correct URL');
+    assert.ok(true, 'calls with correct URL');
 
-    return this.success(201, {
-      id: 'my-vhost-id',
-      status: 'provisioned'
-    });
+    return this.noContent();
   });
 
-  return Ember.run(function(){
-    return vhost.save().then(function(){
-      ok(true, 'vhost did save');
-    });
+  Ember.run(() => {
+    return vhost.save().finally(done);
   });
 });
 
-test('updating PUTs to correct url', function() {
-  expect(2);
+test('updating PUTs to correct url', function(assert) {
+  let done = assert.async();
+  assert.expect(1);
 
-  var store = this.store();
-  var vhost, service;
+  let store = this.store();
+  let vhost, service;
   let vhostId = 'vhost-id';
 
-  Ember.run(function(){
+  Ember.run(() => {
     service = store.createRecord('service', {id: '1'});
     vhost = store.push('vhost', {id: vhostId, status:'provisioned', service:service});
   });
 
   stubRequest('put', `/vhosts/${vhostId}`, function(request){
-    ok(true, 'calls with correct URL');
+    assert.ok(true, 'calls with correct URL');
 
     return this.success({
       id: vhostId,
@@ -62,10 +59,8 @@ test('updating PUTs to correct url', function() {
     });
   });
 
-  return Ember.run(function(){
+  Ember.run(() => {
     vhost.set('virtualDomain', 'new-virtual-domain.com');
-    return vhost.save().then(function(){
-      ok(true, 'vhost did update');
-    });
+    vhost.save().finally(done);
   });
 });


### PR DESCRIPTION
  * update call signatures of overrides of buildURL and other adapter
    hooks to expect snapshots rather than records (fixes ember-data deprecation warnings)
  * Change buildURLWithPrefixMapping to take {property: 'propName', only:['create','update']} style values
  * isolate requestType methods into a mixin for easy extraction later once ember-data 17 comes out,
    the `mixins/adapters/-lookup-methods-with-request-types.js` file has more info.

@mixonic for you

The 2 big changes:

  * updates `buildURLWithPrefixMapping` to take different types of values (changes the property string into a {property:X, only:[Y,Z]} object) so that we can target url modifications to request types (e.g., only prepend /accounts/:account_id to a permission model request for `create` and `update` request types)
  * adds a mixin to the application adapter that uses the `find`, `updateRecord` etc hooks from current ember-data that pass a 4th `requestType` argument to `buildURL`, which we need to enable this fine-grained control.

The `requestType` param changes is in ember-data here:
https://github.com/emberjs/data/commit/e8ceeeb4c099ab084a603c2b2564c56197c65fc5

Isolating these extensions in a mixin should make it a simple step when the next version of ember-data is released to delete that mixin and change the one line in the application adapter where it is used.

Adds a number of tests to the model tests themselves to better describe behavior that I noticed as a result of some of these changes.

Adds tests for the `ssh-key` model, which were previously blocked by ember-data and the tests interacting weirdly such that the unit model tests were erroneously looking for the ssh-key model via a `model:sshKey` container key.