### PR TITLE
Show inviter name when a user is prompted to accept an invitation

### DIFF
--- a/app/claim/template.hbs
+++ b/app/claim/template.hbs
@@ -16,7 +16,8 @@
           </p>
           <form>
             <div>
-              Join organization: {{model.organizationName}}
+              You have been invited by {{model.inviterName}}
+              to join organization {{model.organizationName}}.
             </div>
             <button class="btn btn-primary btn-block btn-lg" {{action "claim"}}>
               Accept organization invitation

--- a/app/models/invitation.js
+++ b/app/models/invitation.js
@@ -5,6 +5,7 @@ export default DS.Model.extend({
   createdAt: DS.attr('date'),
   updatedAt: DS.attr('date'),
   organizationName: DS.attr(),
+  inviterName: DS.attr(),
 
   role: DS.belongsTo('role', {async:true}),
 

--- a/app/signup/invitation/template.hbs
+++ b/app/signup/invitation/template.hbs
@@ -10,7 +10,8 @@
 
         {{#if invitation}}
           <h3>
-            You are invited to join: {{invitation.organizationName}}
+            You have been invited by {{invitation.inviterName}}
+            to join organization {{invitation.organizationName}}.
           </h3>
         {{/if}}
       </div>

--- a/tests/acceptance/claim-test.js
+++ b/tests/acceptance/claim-test.js
@@ -9,7 +9,8 @@ const url = `/claim/${invitationId}/${verificationCode}`;
 const orgName = "My New Org";
 const invitationData = {
   id: invitationId,
-  organization_name: orgName
+  organization_name: orgName,
+  inviter_name: 'Mr inviter'
 };
 
 module('Acceptance: Claim', {
@@ -64,7 +65,7 @@ test(`visiting ${url} as unauthenticated revisits after log in`, function(assert
 
   stubIndexRequests();
 
-  assert.expect(7);
+  assert.expect(8);
 
   visit(url);
   andThen(function(){
@@ -75,8 +76,10 @@ test(`visiting ${url} as unauthenticated revisits after log in`, function(assert
   andThen(function(){
     assert.equal(currentPath(), 'claim');
     assert.equal(currentURL(), `/claim/${invitationId}/${verificationCode}`);
-    assert.ok(find(`:contains(${orgName})`).length,
-              `shows org name "${orgName}" when redirected back to claim`);
+    assert.ok(find(`:contains(${invitationData.organization_name})`).length,
+              `shows org name "${invitationData.organization_name}" when redirected back to claim`);
+    assert.ok(find(`:contains(${invitationData.inviter_name})`).length,
+              `shows inviter name "${invitationData.inviter_name}" when redirected back to claim`);
   });
   clickButton('Accept organization invitation');
   andThen(function(){
@@ -84,12 +87,21 @@ test(`visiting ${url} as unauthenticated revisits after log in`, function(assert
   });
 });
 
-test(`visiting ${url} as authenticated shows org info`, function(assert) {
+test(`visiting ${url} as authenticated shows org name`, function(assert) {
   signInAndVisit(url);
   andThen(() => {
     assert.equal(currentPath(), 'claim');
-    assert.ok(find(`:contains(${orgName})`).length,
-              `shows org name "${orgName}"`);
+    assert.ok(find(`:contains(${invitationData.organization_name})`).length,
+              `shows org name "${invitationData.organization_name}"`);
+  });
+});
+
+test(`visiting ${url} as authenticated shows inviter name`, function(assert) {
+  signInAndVisit(url);
+  andThen(() => {
+    assert.equal(currentPath(), 'claim');
+    assert.ok(find(`:contains(${invitationData.inviter_name})`).length,
+              `shows inviter name "${invitationData.inviter_name}"`);
   });
 });
 

--- a/tests/acceptance/signup/invitation-test.js
+++ b/tests/acceptance/signup/invitation-test.js
@@ -13,15 +13,17 @@ let orgName = 'Great Co.';
 let invitationId     = 'some-invite';
 let verificationCode = 'some-verification-code';
 
-let invitationData = {
-  id: invitationId,
-  organization_name: orgName
-};
-
 let userInput = {
   email: 'good@email.com',
   password: 'Correct#Password1!3',
   name: 'Test User'
+};
+
+let invitationData = {
+  id: invitationId,
+  organization_name: orgName,
+  email: userInput.email,
+  inviter_name: 'Houdini'
 };
 
 let url = `/signup/invitation/${invitationId}/${verificationCode}`;
@@ -43,13 +45,28 @@ test(`visiting ${url} when logged in redirects`, function(assert) {
 test(`visiting ${url} shows organization name`, function(assert) {
   visit(url);
   andThen(() => {
-    assert.ok(find(`:contains(${orgName})`).length,
-              `has org name "${orgName}"`);
+    assert.ok(find(`:contains(${invitationData.organization_name})`).length,
+              `has org name "${invitationData.organization_name}"`);
+  });
+});
+
+test(`visiting ${url} shows inviter name`, function(assert) {
+  visit(url);
+  andThen(() => {
+    assert.ok(find(`:contains(${invitationData.inviter_name})`).length,
+              `has inviter name "${invitationData.inviter_name}"`);
   });
 });
 
 test(`visiting ${url} shows signup inputs`, function(assert) {
   signupInputsTest(url);
+});
+
+test(`visiting ${url} pre-fills user's email from invitation`, function(assert){
+  visit(url);
+  andThen(() => {
+    expectInput('email', {value: invitationData.email});
+  });
 });
 
 test(`visiting ${url} shows no organization input`, function(assert) {


### PR DESCRIPTION
refs #252 

This PR in auth will add an `inviterName` property to invitations: https://github.com/aptible/auth.aptible.com/pull/135.

This PR changes diesel to show the inviter name to a user on the "accept invitation" and "signup from invitation" pages.

Looks like:

![image](https://cloud.githubusercontent.com/assets/2023/6984580/514c8c04-d9f8-11e4-8f79-b9891fda16ac.png)

and

![image](https://cloud.githubusercontent.com/assets/2023/6984591/7553c8a6-d9f8-11e4-9b48-60a5971d6806.png)

cc @sandersonet This could use some design improvement. And did you want to show additional information on the accept invitation page?