### PR TITLE
Clicking "remove" destroys the user record

### DIFF
--- a/app/adapters/user.js
+++ b/app/adapters/user.js
@@ -1,6 +1,10 @@
 import AuthAdapter from './auth';
+import buildURLWithPrefixMap from '../utils/build-url-with-prefix-map';
 
 export default AuthAdapter.extend({
+  buildURL: buildURLWithPrefixMap({
+    'organizations': {property: 'organizationId', only:['delete']}
+  }),
 
   ajaxOptions: function(url, type, options) {
     var hash = this._super(url, type, options);

--- a/app/organization/members/edit/route.js
+++ b/app/organization/members/edit/route.js
@@ -26,11 +26,18 @@ export default Ember.Route.extend({
     controller.set('changeset', changeset);
   },
 
-
   actions: {
     cancel() {
       this.transitionTo('organization.members');
     },
+
+    remove(user){
+      user.set('organizationId', this.modelFor('organization').get('id'));
+      user.destroyRecord().then(() => {
+        this.transitionTo('organization.members');
+      });
+    },
+
     save() {
       const promises = [];
       const changeset = this.controller.get('changeset');

--- a/app/organization/members/edit/template.hbs
+++ b/app/organization/members/edit/template.hbs
@@ -35,9 +35,11 @@
           <button {{action 'save'}} class='btn btn-primary' type='submit'>
             Save
           </button>
-          <button {{action 'remove' model}} class='btn btn-danger pull-right'>
-            Remove {{model.name}} from {{organization.name}}
-          </button>
+          {{#unless (eq session.currentUser model)}}
+            <button {{action 'remove' model}} class='btn btn-danger pull-right'>
+              Remove {{model.name}} from {{organization.name}}
+            </button>
+          {{/unless}}
         </div>
 
       </div>

--- a/tests/unit/models/user-test.js
+++ b/tests/unit/models/user-test.js
@@ -3,14 +3,31 @@ import {
   test
 } from 'ember-qunit';
 import modelDeps from "../../support/common-model-dependencies";
+import { stubRequest } from "../../helpers/fake-server";
+import Ember from 'ember';
 
 moduleForModel('user', 'model:user', {
   // Specify the other units that are required for this test.
-  needs: modelDeps
+  needs: modelDeps.concat([
+    'adapter:user'
+  ])
 });
 
-test('it exists', function() {
-  var model = this.subject();
-  // var store = this.store();
-  ok(!!model);
+test('DELETEs to /organizations/:org_id/users/:id', function(assert) {
+  assert.expect(1);
+  let done = assert.async();
+  let store = this.store();
+
+  let user = Ember.run(store, 'push', 'user', {id:'userId'});
+  let organization = Ember.run(store, 'push', 'organization', {id:'orgId'});
+
+  stubRequest('delete', '/organizations/orgId/users/userId', function(request){
+    assert.ok(true, 'deletes to correct url');
+    return this.noContent();
+  });
+
+  Ember.run(() => {
+    user.set('organizationId', 'orgId');
+    user.destroyRecord().finally(done);
+  });
 });


### PR DESCRIPTION
fixes #262

@sandersonet for your review

This sends a DELETE /organizations/:org_id/users/:user_id request
when clicking the "Remove user" button on the members edit page.

The button is not shown if the user is looking at their own page.

There is a complementary PR for auth that adds the necessary endpoint:
https://github.com/aptible/auth.aptible.com/pull/136