### PR TITLE
Track analytics on every page, identify upon sign in

### DIFF
--- a/app/application/route.js
+++ b/app/application/route.js
@@ -3,16 +3,6 @@ import Ember from 'ember';
 export default Ember.Route.extend({
   requireAuthentication: false,
   title: 'Aptible Dashboard',
-
-  afterModel: function(){
-    this.analytics.identify();
-    var route = this;
-    this.session.addObserver('currentUser', function(){
-      var email = route.get('currentUser.email');
-      route.analytics.identify(email);
-    });
-  },
-
   activate() {
     if (this.get('features').isEnabled('notifications')) {
       this._oldOnError = Ember.onerror;

--- a/app/components/query-box/component.js
+++ b/app/components/query-box/component.js
@@ -21,7 +21,7 @@ export default Ember.Component.extend({
     submit: function(email){
       if (email) {
         var component = this;
-        this.analytics.identify(email).then(function(){
+        this.analytics.identify(email, {email: email}).then(function(){
           component.analytics.showChat();
         });
       } else {

--- a/app/router.js
+++ b/app/router.js
@@ -2,7 +2,11 @@ import Ember from "ember";
 import config from "./config/environment";
 
 var Router = Ember.Router.extend({
-  location: config.locationType
+  analytics: Ember.inject.service(),
+  location: config.locationType,
+  trackAnalytics: function() {
+    this.get('analytics').page();
+  }.on('didTransition')
 });
 
 export default Router.map(function() {

--- a/app/services/analytics.js
+++ b/app/services/analytics.js
@@ -84,7 +84,7 @@ function load(){
   analytics.SNIPPET_VERSION = '3.0.1';
 }
 
-export default Ember.Object.extend({
+export default Ember.Service.extend({
 
   hasEmail: undefined,
 

--- a/app/signup/index/route.js
+++ b/app/signup/index/route.js
@@ -9,11 +9,5 @@ export default Ember.Route.extend(DisallowAuthenticated, SignupRouteMixin, {
 
     controller.set('model', user);
     controller.set('organization', organization);
-  },
-
-  actions: {
-    didTransition: function(){
-      this.analytics.page('Signup');
-    }
   }
 });

--- a/config/environment.js
+++ b/config/environment.js
@@ -49,10 +49,10 @@ module.exports = function(environment) {
     },
 
     contentSecurityPolicy: {
-      'connect-src': "'self' http://localhost:4000 http://localhost:4001 ws://localhost:35729 ws://0.0.0.0:35729 http://api.mixpanel.com http://api.segment.io http://auth.aptible.foundry.io http://api.aptible.foundry.io",
+      'connect-src': "'self' http://localhost:4000 http://localhost:4001 ws://localhost:35729 ws://0.0.0.0:35729 http://api.mixpanel.com http://api.segment.io http://auth.aptible.foundry.io http://api.aptible.foundry.io https://api-ping.intercom.io wss://*.intercom.io https://*.intercom.io",
       'style-src': "'self' 'unsafe-inline' http://use.typekit.net",
-      'img-src': "'self' http://www.gravatar.com https://secure.gravatar.com http://www.google-analytics.com http://p.typekit.net https://track.customer.io",
-      'script-src': "'self' 'unsafe-inline' https://js.stripe.com https://api.stripe.com http://use.typekit.net http://cdn.segment.com https://assets.customer.io http://www.google-analytics.com http://cdn.mxpnl.com",
+      'img-src': "'self' http://www.gravatar.com https://secure.gravatar.com http://www.google-analytics.com http://p.typekit.net https://track.customer.io https://js.intercomcdn.com",
+      'script-src': "'self' 'unsafe-inline' https://js.stripe.com https://api.stripe.com http://use.typekit.net http://cdn.segment.com https://assets.customer.io http://www.google-analytics.com http://cdn.mxpnl.com https://js.intercomcdn.com https://static.intercomcdn.com https://widget.intercom.io",
       'font-src': "'self' data:",
       'object-src': "http://localhost:4200"
     },

--- a/tests/unit/torii-adapters/aptible-test.js
+++ b/tests/unit/torii-adapters/aptible-test.js
@@ -12,6 +12,11 @@ import modelDeps from "../../support/common-model-dependencies";
 
 var originalWrite, originalRead;
 
+class MockAnalytics {
+  identify() {}
+  page() {}
+}
+
 moduleFor('torii-adapter:aptible', 'Torii Adapter: Aptible', {
   needs: modelDeps,
 
@@ -29,7 +34,8 @@ moduleFor('torii-adapter:aptible', 'Torii Adapter: Aptible', {
     var store = this.container.lookup('store:main');
     var klass = this.container.lookupFactory(this.subjectName);
     return klass.create({
-      store: store
+      store: store,
+      analytics: new MockAnalytics()
     });
   }
 });


### PR DESCRIPTION
A step forward with https://github.com/aptible/diesel.aptible.com/issues/230. This tracks the page on every page change, as well as moving the identify step into the Torii adapter.

@sandersonet for you to review/merge. I suggest you take a look at what kind of data this generates on staging.