### PR TITLE
Validate email, app.handle, account.handle, and database.handle for uniqueness during signup

### DIFF
--- a/app/mixins/controllers/signup.js
+++ b/app/mixins/controllers/signup.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import EmberValidationsMixin from "ember-validations/mixin";
+import config from "../../config/environment";
 
 export default Ember.Mixin.create(EmberValidationsMixin, {
   hasSubmitted: false,
@@ -22,7 +23,11 @@ export default Ember.Mixin.create(EmberValidationsMixin, {
     },
     'model.email': {
       presence: true,
-      email: true
+      email: true,
+      uniqueness: {
+        message: 'is taken.',
+        url: `${config.authBaseUri || ''}/claims/user`
+      }
     },
     'model.password': {
       presence: true,

--- a/app/validators/uniqueness.js
+++ b/app/validators/uniqueness.js
@@ -1,0 +1,45 @@
+import Ember from "ember";
+import Base from 'ember-validations/validators/base';
+import ajax from '../utils/ajax';
+
+export default Base.extend({
+  setupOptions: function() {
+    if(this.options === true) {
+      this.options = {};
+    }
+
+    let options = Ember.$.extend({
+      message: 'is taken.',
+      debounce: 150,
+      type: 'post',
+      data: {},
+    }, this.options);
+
+    this._options = options;
+  }.on('init'),
+
+  getDataPropertyName() {
+    return this.options.paramName || this.property.replace('model.', '');
+  },
+
+  call() {
+    if (!Ember.isBlank(Ember.get(this.model, this.property))) {
+      return Ember.run.debounce(this, this.fetch, this._options.debounce);
+    }
+  },
+
+  fetch() {
+    let options = this._options;
+    let errors = this.errors;
+    options.data[this.getDataPropertyName()] = this.model.get(this.property);
+
+    if(errors === null) {
+      debugger;
+    }
+
+    return ajax(options.url, Ember.$.extend({}, options)).then(() => {
+    }, () => {
+      errors.pushObject(options.message);
+    });
+  }
+});

--- a/app/welcome/first-app/controller.js
+++ b/app/welcome/first-app/controller.js
@@ -1,3 +1,42 @@
 import Ember from "ember";
+import config from "../../config/environment";
+import EmberValidationsMixin from "ember-validations/mixin";
 
-export default Ember.Controller.extend();
+export default Ember.Controller.extend(EmberValidationsMixin, {
+  hasSubmitted: false,
+  validations: {
+    'model.stackHandle': {
+      uniqueness: {
+        message: 'is taken.',
+        paramName: 'handle',
+        url: `${config.apiBaseUri || ''}/claims/account`
+      }
+    },
+    'model.appHandle': {
+      uniqueness: {
+        message: 'is taken.',
+        paramName: 'handle',
+        url: `${config.apiBaseUri || ''}/claims/app`
+      }
+    },
+    'model.dbHandle': {
+      uniqueness: {
+        message: 'is taken.',
+        paramName: 'handle',
+        url: `${config.apiBaseUri || ''}/claims/database`
+      }
+    }
+  },
+  actions: {
+    create: function(){
+      this.validate().then(() => {
+      // model data is already stored on the parent
+      // route (welcome). Just move forward.
+
+      this.transitionTo('welcome.payment-info');
+      }).catch(() => {
+        // Silence the validation exception, display it in UI
+      });
+    },
+  }
+});

--- a/app/welcome/first-app/controller.js
+++ b/app/welcome/first-app/controller.js
@@ -33,7 +33,7 @@ export default Ember.Controller.extend(EmberValidationsMixin, {
       // model data is already stored on the parent
       // route (welcome). Just move forward.
 
-      this.transitionTo('welcome.payment-info');
+      this.transitionToRoute('welcome.payment-info');
       }).catch(() => {
         // Silence the validation exception, display it in UI
       });

--- a/app/welcome/first-app/route.js
+++ b/app/welcome/first-app/route.js
@@ -5,13 +5,6 @@ export var firstAppKey = '_aptible_firstAppData';
 
 export default Ember.Route.extend({
   actions: {
-
-    create: function(){
-      // model data is already stored on the parent
-      // route (welcome). Just move forward.
-      this.transitionTo('welcome.payment-info');
-    },
-
     selectDbType: function(dbType){
       let currentType = Ember.get(this.currentModel, 'dbType');
       if (currentType === dbType) {

--- a/app/welcome/first-app/template.hbs
+++ b/app/welcome/first-app/template.hbs
@@ -17,12 +17,16 @@
                 Lowercase alphanumerics only
               </span>
             </label>
-            {{handle-input class="stack-handle form-control sanitize-handler"
-              placeholder="e.g., organization-prod"
-              name="stack-handle"
-              value=model.stackHandle
-              }}
+            <div class="input-group">
+              {{handle-input class="stack-handle form-control sanitize-handler"
+                placeholder="e.g., organization-prod"
+                name="stack-handle"
+                value=model.stackHandle
+                }}
+              {{validation-feedback error=errors.model.stackHandle value=model.stackHandle fieldName='Environment handle'}}
+            </div>
           </div>
+
           <div class="form-group">
             <label class="block">
               App Handle
@@ -30,12 +34,15 @@
                 Lowercase alphanumerics only
               </span>
             </label>
-            {{handle-input class="app-name form-control sanitize-handler"
-              placeholder="e.g., app-prod"
-              name="app-handle"
-              value=model.appHandle
-              autofocus="true"
-              }}
+            <div class="input-group">
+              {{handle-input class="app-name form-control sanitize-handler"
+                placeholder="e.g., app-prod"
+                name="app-handle"
+                value=model.appHandle
+                autofocus="true"
+                }}
+              {{validation-feedback error=errors.model.appHandle value=model.appHandle fieldName='App handle'}}
+            </div>
           </div>
           <div class="form-group">
             <label>Does your app need a database?</label>
@@ -57,11 +64,14 @@
                   Lowercase alphanumerics only
                 </span>
               </label>
-              {{handle-input class="database-name form-control sanitize-handler"
-                    placeholder="e.g., postgresql-prod"
-                    name="db-handle"
-                    value=model.dbHandle
-                    }}
+              <div class="input-group">
+                {{handle-input class="database-name form-control sanitize-handler"
+                  placeholder="e.g., postgresql-prod"
+                  name="db-handle"
+                  value=model.dbHandle
+                  }}
+                {{validation-feedback error=errors.model.dbHandle value=model.dbHandle fieldName='Database Handle'}}
+              </div>
             </div>
 
             <div class="form-group">

--- a/tests/acceptance/signup/index-test.js
+++ b/tests/acceptance/signup/index-test.js
@@ -9,7 +9,7 @@ import {
 
 let App;
 let signupIndexPath = 'signup.index';
-
+let claimUrl = '/claims/user';
 let userUrl = '/users/my-user';
 let userInput = {
   email: 'good@email.com',
@@ -22,6 +22,9 @@ let url = '/signup';
 module('Acceptance: Signup', {
   setup: function() {
     App = startApp();
+    stubRequest('post', claimUrl, function(request) {
+      return [204, {}, ''];
+    });
   },
   teardown: function() {
     Ember.run(App, 'destroy');

--- a/tests/acceptance/signup/index-test.js
+++ b/tests/acceptance/signup/index-test.js
@@ -9,7 +9,7 @@ import {
 
 let App;
 let signupIndexPath = 'signup.index';
-let claimUrl = '/claims/user';
+let claimUrls = ['/claims/user', '/claims/account', '/claims/app', '/claims/database'];
 let userUrl = '/users/my-user';
 let userInput = {
   email: 'good@email.com',
@@ -22,8 +22,10 @@ let url = '/signup';
 module('Acceptance: Signup', {
   setup: function() {
     App = startApp();
-    stubRequest('post', claimUrl, function(request) {
-      return [204, {}, ''];
+    claimUrls.forEach((claimUrl) => {
+      stubRequest('post', claimUrl, function(request) {
+        return [204, {}, ''];
+      });
     });
   },
   teardown: function() {

--- a/tests/acceptance/signup/invitation-test.js
+++ b/tests/acceptance/signup/invitation-test.js
@@ -12,7 +12,7 @@ let App;
 let orgName = 'Great Co.';
 let invitationId     = 'some-invite';
 let verificationCode = 'some-verification-code';
-
+let claimUrl = '/claims/user';
 let userInput = {
   email: 'good@email.com',
   password: 'Correct#Password1!3',
@@ -32,6 +32,9 @@ module('Acceptance: Signup Invitation', {
   setup: function() {
     App = startApp();
     stubInvitation(invitationData);
+    stubRequest('post', claimUrl, function(request) {
+      return [204, {}, ''];
+    });
   },
   teardown: function() {
     Ember.run(App, 'destroy');

--- a/tests/acceptance/welcome/first-app-test.js
+++ b/tests/acceptance/welcome/first-app-test.js
@@ -1,11 +1,18 @@
 import Ember from 'ember';
 import startApp from '../../helpers/start-app';
-
+import { stubRequest } from "../../helpers/fake-server";
 var application;
+
+let claimUrls = ['/claims/user', '/claims/account', '/claims/app', '/claims/database'];
 
 module('Acceptance: WelcomeFirstApp', {
   setup: function() {
     application = startApp();
+    claimUrls.forEach((claimUrl) => {
+      stubRequest('post', claimUrl, function(request) {
+        return [204, {}, ''];
+      });
+    });
   },
   teardown: function() {
     Ember.run(application, 'destroy');

--- a/tests/unit/validators/uniqueness-test.js
+++ b/tests/unit/validators/uniqueness-test.js
@@ -11,7 +11,8 @@ let claimUrl = '/claims/organization';
 moduleFor('validator:uniqueness', 'UniquenessValidator', {
   setup() {
     model = Ember.Object.create({
-      dependentValidationKeys: {}
+      dependentValidationKeys: {},
+      handle: 'handle'
     });
   }
 });
@@ -34,7 +35,7 @@ test('A valid response should add no error messages', function() {
       }
     });
 
-    validator.fetch().then(() => {
+    validator.validate().then(() => {
       ok(!validator.get('errors.length'), 'has no errors');
       start();
     });
@@ -60,7 +61,7 @@ test('An error response should add an error message', function() {
       }
     });
 
-    validator.fetch().then(() => {
+    validator.validate().finally(() => {
       ok(validator.get('errors.length') === 1, 'has an error');
       equal(validator.get('errors').objectAt(0), "seat's taken!");
       start();

--- a/tests/unit/validators/uniqueness-test.js
+++ b/tests/unit/validators/uniqueness-test.js
@@ -1,0 +1,69 @@
+import {
+  moduleFor,
+  test
+} from 'ember-qunit';
+import Ember from "ember";
+import { stubRequest } from "../../helpers/fake-server";
+
+let model;
+let claimUrl = '/claims/organization';
+
+moduleFor('validator:uniqueness', 'UniquenessValidator', {
+  setup() {
+    model = Ember.Object.create({
+      dependentValidationKeys: {}
+    });
+  }
+});
+
+test('A valid response should add no error messages', function() {
+  let validator;
+  stop();
+
+  stubRequest('post', claimUrl, function(request) {
+    ok(true, 'request was made');
+    return [204, {}, ''];
+  });
+
+  Ember.run(() => {
+    validator = this.subject({
+      model: model,
+      property: 'handle',
+      options: {
+        url: claimUrl
+      }
+    });
+
+    validator.fetch().then(() => {
+      ok(!validator.get('errors.length'), 'has no errors');
+      start();
+    });
+  });
+});
+
+test('An error response should add an error message', function() {
+  let validator;
+  stop();
+
+  stubRequest('post', claimUrl, function(request) {
+    ok(true, 'request was made');
+    return [400, {}, ''];
+  });
+
+  Ember.run(() => {
+    validator = this.subject({
+      model: model,
+      property: 'handle',
+      options: {
+        url: claimUrl,
+        message: "seat's taken!"
+      }
+    });
+
+    validator.fetch().then(() => {
+      ok(validator.get('errors.length') === 1, 'has an error');
+      equal(validator.get('errors').objectAt(0), "seat's taken!");
+      start();
+    });
+  });
+});


### PR DESCRIPTION
This PR adds a remote validator. It's used here to validate an attribute's uniqueness, but could easily be used for any kind of remote validation.  This requires a `/claims/:model_type` endpoint that returns a 204 when valid or an error status when invalid (https://github.com/aptible/auth.aptible.com/pull/139)